### PR TITLE
Tools: Add workflow to build theme

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,15 +26,26 @@ jobs:
             - name: Build
               run: yarn workspaces run build
 
-            - name: Ignore .gitignore
+            - name: Trim the repo down to just the theme
               run: |
-                  git add source/wp-content/themes/wporg-parent-2021/build/* --force
+                  cp -R source/wp-content/themes/wporg-parent-2021 theme
+                  git rm -r .
+                  mv theme/ .
+                  rm -r theme
+
+            # Add a composer.json so we can set the type to `wordpress-theme`.
+            - name: Create the composer.json
+              run: |
+                  echo "{\n\t\"name\": \"wporg/wporg-parent-2021\",\n\t\"type\": \"wordpress-theme\"\n}" > composer.json
+
+            - name: Add all the theme files
+              run: |
+                  git add * --force
 
             - name: Commit and push
               uses: actions-js/push@a52398fac807b0c1e5f1492c969b477c8560a0ba # 1.3
               with:
                   github_token: ${{ secrets.GITHUB_TOKEN }}
                   branch: build
-                  directory: ./source/wp-content/themes/wporg-parent-2021
                   force: true
                   message: 'Build: ${{ github.sha }}'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,8 +2,7 @@ name: Build and push to build branch.
 
 on:
     push:
-        # `try/build-branch` only here for testing, can remove once PR is merged.
-        branches: [trunk, try/build-branch]
+        branches: [trunk]
 
 jobs:
     build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,11 +28,11 @@ jobs:
 
             - name: Trim the repo down to just the theme
               run: |
-                  cp -R source/wp-content/themes/wporg-parent-2021 theme
-                  rm -rf theme/node_modules
-                  git rm -r .
-                  mv theme/* .
-                  rm -r theme
+                  rm -rf source/wp-content/themes/wporg-parent-2021/node_modules
+                  mv source/wp-content/themes/wporg-parent-2021 $RUNNER_TEMP
+                  git rm -rfq .
+                  rm -rf *
+                  mv $RUNNER_TEMP/wporg-parent-2021/* .
 
             # Add a composer.json so we can set the type to `wordpress-theme`.
             - name: Create the composer.json

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
               run: |
                   cp -R source/wp-content/themes/wporg-parent-2021 theme
                   git rm -r .
-                  mv theme/ .
+                  mv theme/* .
                   rm -r theme
 
             # Add a composer.json so we can set the type to `wordpress-theme`.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,40 @@
+name: Build and push to build branch.
+
+on:
+    push:
+        # `try/build-branch` only here for testing, can remove once PR is merged.
+        branches: [trunk, try/build-branch]
+
+jobs:
+    build:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2.4.0
+
+            - name: Install NodeJS
+              uses: actions/setup-node@5b52f097d36d4b0b2f94ed6de710023fbb8b2236 # v3.1.0
+              with:
+                  node-version-file: '.nvmrc'
+                  cache: 'yarn'
+
+            - name: Install all dependencies
+              run: |
+                  composer install
+                  yarn
+
+            - name: Build
+              run: yarn workspaces run build
+
+            - name: Ignore .gitignore
+              run: |
+                  git add source/wp-content/themes/wporg-parent-2021/build/* --force
+
+            - name: Commit and push
+              uses: actions-js/push@a52398fac807b0c1e5f1492c969b477c8560a0ba # 1.3
+              with:
+                  github_token: ${{ secrets.GITHUB_TOKEN }}
+                  branch: build
+                  directory: ./source/wp-content/themes/wporg-parent-2021
+                  force: true
+                  message: 'Build: ${{ github.sha }}'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,6 +29,7 @@ jobs:
             - name: Trim the repo down to just the theme
               run: |
                   cp -R source/wp-content/themes/wporg-parent-2021 theme
+                  rm -rf theme/node_modules
                   git rm -r .
                   mv theme/* .
                   rm -r theme

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,7 @@ jobs:
             # Add a composer.json so we can set the type to `wordpress-theme`.
             - name: Create the composer.json
               run: |
-                  echo "{\n\t\"name\": \"wporg/wporg-parent-2021\",\n\t\"type\": \"wordpress-theme\"\n}" > composer.json
+                  echo "{\"name\": \"wporg/wporg-parent-2021\",\"type\": \"wordpress-theme\"}" > composer.json
 
             - name: Add all the theme files
               run: |


### PR DESCRIPTION
Fixes #5 — Create a build branch that only contains the parent theme files, along with a new `composer.json` to identify this as a `wordpress-theme`.

You can verify it's working by looking at [the Checks tab](https://github.com/WordPress/wporg-parent-2021/pull/6/checks) & [the build branch](https://github.com/WordPress/wporg-parent-2021/tree/build) generated by this.