### PR TITLE
Block Style: Add "Serif" style for paragraphs

### DIFF
--- a/source/wp-content/themes/wporg-parent-2021/inc/block-styles.php
+++ b/source/wp-content/themes/wporg-parent-2021/inc/block-styles.php
@@ -85,6 +85,15 @@ function setup_block_styles() {
 			'label'        => __( 'Features', 'wporg' ),
 		)
 	);
+
+	register_block_style(
+		'core/paragraph',
+		array(
+			'name'         => 'serif',
+			'label'        => __( 'Serif', 'wporg' ),
+			'style_handle' => STYLE_HANDLE,
+		)
+	);
 }
 
 /**

--- a/source/wp-content/themes/wporg-parent-2021/sass/block-styles.scss
+++ b/source/wp-content/themes/wporg-parent-2021/sass/block-styles.scss
@@ -169,3 +169,9 @@
 		line-height: var(--wporg--style--feature--li-height);
 	}
 }
+
+.is-style-serif {
+	font-family: var(--wp--custom--heading--typography--font-family);
+	font-size: var(--wp--preset--font-size--heading-5);
+	line-height: var(--wp--custom--heading--level-5--typography--line-height);
+}


### PR DESCRIPTION
Fixes #21. Add a block style to switch the font of a paragraph block.

### Screenshots

Block style is available on the paragraph block:

<img width="285" alt="Screen Shot 2022-08-02 at 12 50 00 PM" src="https://user-images.githubusercontent.com/541093/182430849-381bd51d-c778-43c0-84c5-1aa61318ea50.png">

| Before | After |
|--------|-------|
| <img src="https://user-images.githubusercontent.com/541093/182430763-ffc08869-1526-4093-a6eb-fabb54a2948b.png"> | <img src="https://user-images.githubusercontent.com/541093/182430764-32fc0b26-715a-42a7-b66b-40255a732ca8.png"> |

### How to test the changes in this Pull Request:

1. Create or edit a post/page
2. Add a paragraph
3. Switch to the serif block style
4. The font should change in the editor
5. Save the post, view it
6. The font should be serif for that paragraph on the front end
