### PR TITLE
Block Style: Add Features list style

### DIFF
--- a/source/wp-content/themes/wporg-parent-2021/inc/block-styles.php
+++ b/source/wp-content/themes/wporg-parent-2021/inc/block-styles.php
@@ -77,6 +77,14 @@ function setup_block_styles() {
 			'label'        => __( 'Outline on dark', 'wporg' ),
 		)
 	);
+
+	register_block_style(
+		'core/list',
+		array(
+			'name'         => 'features',
+			'label'        => __( 'Features', 'wporg' ),
+		)
+	);
 }
 
 /**

--- a/source/wp-content/themes/wporg-parent-2021/sass/block-styles.scss
+++ b/source/wp-content/themes/wporg-parent-2021/sass/block-styles.scss
@@ -121,3 +121,50 @@
 		}
 	}
 }
+
+.is-style-features {
+	--wporg--style--feature--offset: 0.2em;
+	padding: 0;
+	list-style: none;
+	font-size: var(--wp--preset--font-size--heading-1);
+	font-weight: 200;
+	line-height: 1.1;
+
+	li {
+		overflow: hidden;
+		box-sizing: border-box;
+		height: 1.1em;
+		padding-top: var(--wporg--style--feature--offset);
+		padding-left: var(--wp--preset--spacing--50);
+		padding-right: var(--wp--preset--spacing--50);
+		color: #6682ff; // Hardcoded color for better contrast.
+		border-bottom: 1px solid var(--wp--preset--color--blueberry-3);
+		transition: all 0.2s ease-in-out;
+
+		a {
+			text-decoration: none;
+		}
+
+		&:hover,
+		&:focus,
+		&:focus-within {
+			padding-top: 0;
+			color: var(--wp--preset--color--blueberry-1);
+		}
+	}
+
+	// Make sure to remove padding from blocks with background colors.
+	&.has-background {
+		padding: 0;
+	}
+
+	// Use the set text color, if one exists.
+	&.has-text-color li {
+		color: inherit;
+	}
+
+	// Blocks with set font sizes should still use this line height.
+	&[class*="-font-size"] {
+		line-height: 1.1;
+	}
+}

--- a/source/wp-content/themes/wporg-parent-2021/sass/block-styles.scss
+++ b/source/wp-content/themes/wporg-parent-2021/sass/block-styles.scss
@@ -131,7 +131,7 @@
 	font-weight: 200;
 	line-height: var(--wporg--style--feature--li-height);
 
-	li {
+	> li {
 		overflow: hidden;
 		box-sizing: border-box;
 		height: calc(var(--wporg--style--feature--li-height) * 1em);

--- a/source/wp-content/themes/wporg-parent-2021/sass/block-styles.scss
+++ b/source/wp-content/themes/wporg-parent-2021/sass/block-styles.scss
@@ -124,16 +124,17 @@
 
 .is-style-features {
 	--wporg--style--feature--offset: 0.2em;
+	--wporg--style--feature--li-height: 1.1;
 	padding: 0;
 	list-style: none;
 	font-size: var(--wp--preset--font-size--heading-1);
 	font-weight: 200;
-	line-height: 1.1;
+	line-height: var(--wporg--style--feature--li-height);
 
 	li {
 		overflow: hidden;
 		box-sizing: border-box;
-		height: 1.1em;
+		height: calc(var(--wporg--style--feature--li-height) * 1em);
 		padding-top: var(--wporg--style--feature--offset);
 		padding-left: var(--wp--preset--spacing--50);
 		padding-right: var(--wp--preset--spacing--50);
@@ -165,6 +166,6 @@
 
 	// Blocks with set font sizes should still use this line height.
 	&[class*="-font-size"] {
-		line-height: 1.1;
+		line-height: var(--wporg--style--feature--li-height);
 	}
 }

--- a/source/wp-content/themes/wporg-parent-2021/theme.json
+++ b/source/wp-content/themes/wporg-parent-2021/theme.json
@@ -459,7 +459,7 @@
 				{
 					"name": "Medium",
 					"slug": 50,
-					"size": "60px"
+					"size": "clamp( 40px, calc( 100vw / 16 ), 60px )"
 				},
 				{
 					"name": "Large",


### PR DESCRIPTION
Fixes https://github.com/WordPress/wporg-main-2022/issues/32 — this adds a block style to the list block. Using this style bumps the font size, adds a bottom border, and offsets the content below the baseline slightly. On hover (or focus, if there's a link), the line animates slightly up to be fully visible.

### Screenshots

Editor

![editor](https://user-images.githubusercontent.com/541093/182730715-df810fa0-2286-489d-a273-dacc5c2cf18f.png)

Front end

![default](https://user-images.githubusercontent.com/541093/182730717-c5d38416-ada8-4d9d-bf28-8530c8df9252.png)

With "Intuitive" hovered.

![hover](https://user-images.githubusercontent.com/541093/182730711-316bd667-c95f-491d-8466-ecea3012ebc7.png)

Small screen

![Screen Shot 2022-08-03 at 19 39 09](https://user-images.githubusercontent.com/541093/182730906-c68dbacb-1d91-4838-a54d-ff70aab7af05.png)

### How to test the changes in this Pull Request:

1. Add a list to a page, select "Features" in the sidebar.
2. Add items to the list
3. It should look like the screenshots
