### PR TITLE
Block: Add styles for news posts block.

### DIFF
--- a/source/wp-content/themes/wporg-parent-2021/theme.json
+++ b/source/wp-content/themes/wporg-parent-2021/theme.json
@@ -425,6 +425,21 @@
 						"fontSize": "var(--wp--preset--font-size--extra-small)"
 					}
 				}
+			},
+			"multisite-latests-post": {
+				"link": {
+					"color": "var(--wp--preset--color--charcoal-1)",
+					"spacing": "var(--wp--preset--spacing--10)",
+					"details": {
+						"fontSize": "var(--wp--preset--font-size--small)"
+					}
+				},
+				"spacing":  "var(--wp--preset--spacing--40)",
+				"title": {
+					"fontFamily": "var(--wp--preset--font-family--eb-garamond)",
+					"fontSize": "var(--wp--preset--font-size--heading-5)",
+					"lineHeight": "var(--wp--custom--heading--level-3--typography--line-height)"
+				}
 			}
 		},
 		"layout": {


### PR DESCRIPTION
See https://github.com/WordPress/wporg-mu-plugins/pull/236.

This PR adds custom CSS properties to the `block.json` to be used in the news posts list.

Should not be merged until https://github.com/WordPress/wporg-mu-plugins/pull/236 is complete.