### PR TITLE
Fix Heading with a highlight has a yellow background

### DIFF
--- a/source/wp-content/themes/wporg-parent-2021/sass/base/_elements.scss
+++ b/source/wp-content/themes/wporg-parent-2021/sass/base/_elements.scss
@@ -12,6 +12,11 @@ a {
 	}
 }
 
+// Text highlighted via the editor
+mark.has-inline-color {
+	background-color: transparent;
+}
+
 // Links that appear in the main content area
 .block-editor-block-list__layout a, // Needed for the post area
 .wp-block-post-content a {


### PR DESCRIPTION
Text highlighted in the editor produces a `mark` element which has a yellow background color by default in Chrome. This PR sets the background color to be transparent if the element has a text color applied. If a background color is also applied for the highlight then the inline style will still override this.

Fixes https://github.com/WordPress/wporg-main-2022/issues/37

### Screenshots

| Before | After |
|--------|-------|
| ![image](https://user-images.githubusercontent.com/541093/182264415-9e7f5320-9ddd-4d4c-b058-9aa94cfdadea.png)  | ![Screen Shot 2022-08-04 at 6 31 32 PM](https://user-images.githubusercontent.com/1017872/182778805-8878c7a9-2fd5-46ca-b8d9-86f2d1ce490d.jpg) |

### How to test the changes in this Pull Request:

1. Build the styles and copy `style.css`
2. Replace the corresponding file in a locally running instance of https://github.com/WordPress/wporg-main-2022
3. Observe that the highlighted text on the front page in the frontend has no yellow background
4. Try adding a custom background color to that highlighted text and ensure that it still works in the editor and on the frontend