### PR TITLE
Block Style: Links list style (alternative)

### DIFF
--- a/source/wp-content/themes/wporg-parent-2021/inc/block-styles.php
+++ b/source/wp-content/themes/wporg-parent-2021/inc/block-styles.php
@@ -87,6 +87,14 @@ function setup_block_styles() {
 	);
 
 	register_block_style(
+		'core/list',
+		array(
+			'name'         => 'links-list',
+			'label'        => __( 'Links', 'wporg' ),
+		)
+	);
+
+	register_block_style(
 		'core/paragraph',
 		array(
 			'name'         => 'serif',

--- a/source/wp-content/themes/wporg-parent-2021/sass/base/_normalize.scss
+++ b/source/wp-content/themes/wporg-parent-2021/sass/base/_normalize.scss
@@ -48,6 +48,7 @@ body[class] {
 		--wp--preset--font-size--heading-4: var(--wp--custom--heading--level-4--breakpoint--small-only--typography--font-size);
 		--wp--preset--font-size--heading-5: var(--wp--custom--heading--level-5--breakpoint--small-only--typography--font-size);
 		--wp--preset--font-size--heading-6: var(--wp--custom--heading--level-6--breakpoint--small-only--typography--font-size);
+		--wp--preset--font-size--extra-large: var(--wp--custom--body--extra-large--breakpoint--small-only--typography--font-size);
 
 		--wp--custom--heading--cta--typography--line-height: var(--wp--custom--heading--cta--breakpoint--small-only--typography--line-height);
 		--wp--custom--heading--level-1--typography--line-height: var(--wp--custom--heading--level-1--breakpoint--small-only--typography--line-height);
@@ -56,5 +57,6 @@ body[class] {
 		--wp--custom--heading--level-4--typography--line-height: var(--wp--custom--heading--level-4--breakpoint--small-only--typography--line-height);
 		--wp--custom--heading--level-5--typography--line-height: var(--wp--custom--heading--level-5--breakpoint--small-only--typography--line-height);
 		--wp--custom--heading--level-6--typography--line-height: var(--wp--custom--heading--level-6--breakpoint--small-only--typography--line-height);
+		--wp--custom--body--extra-large--typography--line-height: var(--wp--custom--body--extra-large--breakpoint--small-only--typography--line-height);
 	}
 }

--- a/source/wp-content/themes/wporg-parent-2021/sass/block-styles.scss
+++ b/source/wp-content/themes/wporg-parent-2021/sass/block-styles.scss
@@ -170,6 +170,47 @@
 	}
 }
 
+.is-style-links-list {
+	padding: 0;
+	list-style: none;
+	font-size: var(--wp--preset--font-size--extra-large);
+	line-height: 1.125;
+
+	> li {
+		padding: 14px 0;
+		// Use the current text color, to support different text/background color combos.
+		border-bottom: 1px solid currentColor;
+
+		a {
+			text-decoration: none;
+
+			&:hover,
+			&:focus {
+				text-decoration-line: underline;
+				text-decoration-thickness: 1px;
+				text-underline-offset: 0.15em;
+			}
+		}
+
+		&:first-of-type {
+			border-top: 1px solid currentColor;
+		}
+	}
+
+	// Remove padding from blocks with background colors.
+	&.has-background {
+		padding: 0;
+	}
+
+	// If the text color is set to white, the border should be semi-transparent.
+	// This matches the design, when the list is used inside a blue background.
+	&.has-white-color > li,
+	.has-white-color > & > li,
+	.has-white-color *:not(.has-text-color) & > li {
+		border-color: rgba(255 255 255 / 0.2);
+	}
+}
+
 .is-style-serif {
 	font-family: var(--wp--custom--heading--typography--font-family);
 	font-size: var(--wp--preset--font-size--heading-5);

--- a/source/wp-content/themes/wporg-parent-2021/theme.json
+++ b/source/wp-content/themes/wporg-parent-2021/theme.json
@@ -232,6 +232,14 @@
 				"extra-large": {
 					"typography": {
 						"lineHeight": 1.58
+					},
+					"breakpoint": {
+						"small-only": {
+							"typography": {
+								"fontSize": "20px",
+								"lineHeight": 1.5
+							}
+						}
 					}
 				},
 				"huge": {


### PR DESCRIPTION
Fixes https://github.com/WordPress/wporg-main-2022/issues/29

This is an alternative to #33 — I wanted to see how we could support custom colors and what should happen if this block is inside colorful groups. The block itself, with no settings, just uses the default text & link colors.

<img width="494" alt="Screen Shot 2022-08-05 at 12 26 32 PM" src="https://user-images.githubusercontent.com/541093/183120509-b15773df-a9d9-444b-8a7a-594bef0cde07.png">

When it's in a container with white text, the border goes to 20% opacity to match the design. This is probably the context it will appear on the site in.

<img width="542" alt="Screen Shot 2022-08-05 at 12 40 07 PM" src="https://user-images.githubusercontent.com/541093/183122516-fbe7702d-7961-4d1c-a7cf-f6a4bb91fcfe.png">

Otherwise it matches the current text color. The border is full-opacity here because we can't turn down the opacity without knowing what color it is. White is the special case to match the design.

<img width="498" alt="Screen Shot 2022-08-05 at 12 40 51 PM" src="https://user-images.githubusercontent.com/541093/183122631-c3ed3511-082f-418f-a3b0-eb4291e3885c.png">

### Screenshots

| Editor | Frontend |
|--------|-------|
| ![](https://user-images.githubusercontent.com/541093/183120081-a2f6b501-b3f9-4dce-97aa-a236f82d8db0.png) | ![](https://user-images.githubusercontent.com/541093/183120086-f38e55a3-d9eb-487a-84e1-adaa36b0b09d.png) |

### How to test the changes in this Pull Request:

1. Add a list block
2. Set text colors & background colors, it should update to match
3. Reset the colors
4. Put it in a group or columns block
5. Set some colors on the container block, it should update to match
