### PR TITLE
Block Style: Add a "With Arrow" style to the Heading block

### DIFF
--- a/source/wp-content/themes/wporg-parent-2021/images/right-arrow.svg
+++ b/source/wp-content/themes/wporg-parent-2021/images/right-arrow.svg
@@ -1,1 +1,0 @@
-<svg width="670" height="120" fill="none" xmlns="http://www.w3.org/2000/svg"><path stroke="#fff" stroke-width="1.5" d="M0 60h669M609.928 1l59 59-59 59"/></svg>

--- a/source/wp-content/themes/wporg-parent-2021/inc/block-styles.php
+++ b/source/wp-content/themes/wporg-parent-2021/inc/block-styles.php
@@ -83,6 +83,7 @@ function setup_block_styles() {
 		array(
 			'name'         => 'features',
 			'label'        => __( 'Features', 'wporg' ),
+			'style_handle' => STYLE_HANDLE,
 		)
 	);
 
@@ -108,6 +109,15 @@ function setup_block_styles() {
 		array(
 			'name'         => 'short-text',
 			'label'        => __( 'Short text', 'wporg' ),
+			'style_handle' => STYLE_HANDLE,
+		)
+	);
+
+	register_block_style(
+		'core/heading',
+		array(
+			'name'         => 'with-arrow',
+			'label'        => __( 'With Arrow', 'wporg' ),
 			'style_handle' => STYLE_HANDLE,
 		)
 	);

--- a/source/wp-content/themes/wporg-parent-2021/patterns/heading-with-arrow.php
+++ b/source/wp-content/themes/wporg-parent-2021/patterns/heading-with-arrow.php
@@ -6,12 +6,12 @@
  */
 
 ?>
-<!-- wp:group {"align":"full","backgroundColor":"blueberry-1"} -->
-<div class="wp-block-group alignfull has-blueberry-1-background-color has-background">
-	<!-- wp:group {"align":"full","style":{"elements":{"link":{"color":{"text":"var:preset|color|white"}}},"spacing":{"padding":{"top":"97px","bottom":"97px"},"blockGap":"0px"}},"className":"wporg-pattern__heading-with-arrow"} -->
-	<div class="wp-block-group alignfull wporg-pattern__heading-with-arrow has-link-color" style="padding-top:97px;padding-bottom:97px">
-		<!-- wp:heading {"style":{"typography":{"fontStyle":"normal","fontWeight":"300","lineHeight":"1.1","letterSpacing":"-0.02em"}},"fontSize":"heading-cta","fontFamily":"inter"} -->
-		<h2 class="has-inter-font-family has-heading-cta-font-size" style="font-style:normal;font-weight:300;letter-spacing:-0.02em;line-height:1.1"><a href="https://wordpress.org/download/">Get started</a></h2>
+<!-- wp:group {"align":"full","style":{"elements":{"link":{"color":{"text":"var:preset|color|white"}}},"spacing":{"padding":{"top":"var:preset|spacing|60","right":"var:preset|spacing|60","bottom":"var:preset|spacing|60","left":"var:preset|spacing|60"}}},"backgroundColor":"blueberry-1","textColor":"white","layout":{"inherit":true}} -->
+<div class="wp-block-group alignfull has-white-color has-blueberry-1-background-color has-text-color has-background has-link-color" style="padding-top:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--60);padding-bottom:var(--wp--preset--spacing--60);padding-left:var(--wp--preset--spacing--60)">
+	<!-- wp:group {"align":"wide"} -->
+	<div class="wp-block-group alignwide">
+		<!-- wp:heading {"align":"wide","className":"is-style-with-arrow","fontSize":"heading-1","fontFamily":"inter"} -->
+		<h2 class="alignwide is-style-with-arrow has-inter-font-family has-heading-1-font-size"><a href="https://wordpress.org/download/">Get started</a></h2>
 		<!-- /wp:heading -->
 	</div>
 	<!-- /wp:group -->

--- a/source/wp-content/themes/wporg-parent-2021/patterns/heading-with-arrow.php
+++ b/source/wp-content/themes/wporg-parent-2021/patterns/heading-with-arrow.php
@@ -10,8 +10,8 @@
 <div class="wp-block-group alignfull has-white-color has-blueberry-1-background-color has-text-color has-background has-link-color" style="padding-top:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--60);padding-bottom:var(--wp--preset--spacing--60);padding-left:var(--wp--preset--spacing--60)">
 	<!-- wp:group {"align":"wide"} -->
 	<div class="wp-block-group alignwide">
-		<!-- wp:heading {"align":"wide","className":"is-style-with-arrow","fontSize":"heading-1","fontFamily":"inter"} -->
-		<h2 class="alignwide is-style-with-arrow has-inter-font-family has-heading-1-font-size"><a href="https://wordpress.org/download/">Get started</a></h2>
+		<!-- wp:heading {"align":"wide","className":"is-style-with-arrow","fontSize":"heading-cta","fontFamily":"inter"} -->
+		<h2 class="alignwide is-style-with-arrow has-inter-font-family has-heading-cta-font-size"><a href="https://wordpress.org/download/">Get started</a></h2>
 		<!-- /wp:heading -->
 	</div>
 	<!-- /wp:group -->

--- a/source/wp-content/themes/wporg-parent-2021/sass/block-styles.scss
+++ b/source/wp-content/themes/wporg-parent-2021/sass/block-styles.scss
@@ -236,11 +236,14 @@
 	--wporg--style--with-arrow--border-size: 1px;
 
 	position: relative;
-	display: flex;
+	display: grid;
 	align-items: center;
+	grid-template-columns: auto;
+	gap: 0.25em;
 
-	@media (max-width: #{ ($break-large - 1) }) {
-		display: grid;
+	@include break-large() {
+		grid-template-columns: auto 1fr;
+		gap: 0.5em;
 	}
 
 	&::before,
@@ -249,19 +252,20 @@
 		display: block;
 		transition: all 0.15s linear;
 		box-sizing: border-box;
+		grid-row: 1;
+		grid-column: 2;
 
 		@media (max-width: #{ ($break-large - 1) }) {
 			grid-row: 2;
 			grid-column: 1;
-			margin-top: 0.25em;
 		}
 	}
 
 	&::before {
-		order: 3;
-		// Offset by the width of the square and the extra space to the corner point.
-		// Add back in the border width to prevent the end poking out under the arrow.
-		margin-left: calc(#{($arrow_size * -1) - ($half_hyp - math.div($arrow-size, 2))} + var(--wporg--style--with-arrow--border-size));
+		position: relative;
+		// Pull the arrow back by the extra space to the corner point. Add back
+		// the border width to prevent the end poking out under the arrow.
+		left: calc(#{($half_hyp - math.div($arrow-size, 2)) * -1} + var(--wporg--style--with-arrow--border-size));
 		height: $arrow_size;
 		min-width: $arrow_size;
 		max-width: $arrow_size;
@@ -269,15 +273,13 @@
 		border-right: var(--wporg--style--with-arrow--border-size) solid currentColor;
 		transform: rotate(45deg);
 		transform-origin: center;
+		justify-self: end;
 
 		@media (max-width: #{ ($break-large - 1) }) {
 			// Use a smaller arrow on small screens.
 			$arrow_size: 0.5em;
 			$half_hyp: math.div(($arrow_size * $sqrt_2), 2);
 
-			margin-left: 0;
-			justify-self: end;
-			position: relative;
 			// Since this is Sass, not custom properties, the properties also need to be set again.
 			left: calc(#{($half_hyp - math.div($arrow-size, 2)) * -1} + var(--wporg--style--with-arrow--border-size));
 			height: $arrow_size;
@@ -287,8 +289,6 @@
 	}
 
 	&::after {
-		flex: 1;
-		margin-left: math.div($arrow_size, 2);
 		height: var(--wporg--style--with-arrow--border-size);
 		width: 100%;
 		min-width: 30vw;

--- a/source/wp-content/themes/wporg-parent-2021/sass/block-styles.scss
+++ b/source/wp-content/themes/wporg-parent-2021/sass/block-styles.scss
@@ -1,3 +1,4 @@
+@use "sass:math";
 @import "base/breakpoints";
 
 // A two-column grid, with a narrower left column and content centered in the right column.
@@ -221,72 +222,108 @@
 	line-height: var(--wp--custom--body--short-text--typography--line-height);
 }
 
-.wporg-pattern__heading-with-arrow {
-	display: flex;
-	flex-direction: row;
-	justify-content: center;
+.is-style-with-arrow {
+	// Note, these are Sass variables to make the math easier. While we could do
+	// this with `calc()`s, it would be even more unruly.
+	$arrow_size: 1em;
+	// Once rotated, the diagonal of the square is the hypotenuse of an isosceles
+	// triangle, which can be calculated by multiplying the side × √2. We only need
+	// the halfway point, so divide that by 2.
+	$sqrt_2: 1.4142;
+	$half_hyp: math.div(($arrow_size * $sqrt_2), 2);
 
-	&:hover,
-	&:focus-within {
-		background-color: rgba(0, 0, 0, 0.1);
-		transition: background-color 0.15s linear;
+	// This can be a custom property since we could let the editor control later.
+	--wporg--style--with-arrow--border-size: 1px;
+
+	position: relative;
+	display: flex;
+	align-items: center;
+
+	@media (max-width: #{ ($break-large - 1) }) {
+		display: grid;
 	}
 
-	// href added for specificity.
-	a[href] {
-		display: flex;
-		flex-direction: column;
-		align-items: left;
-		text-decoration: none;
+	&::before,
+	&::after {
+		content: "";
+		display: block;
+		transition: all 0.15s linear;
+		box-sizing: border-box;
 
-		&::after {
-			content: "";
-			display: block;
-			height: 38px;
-			background-image: url(../images/right-arrow.svg);
-			background-position: center right;
-			background-repeat: no-repeat;
-			pointer-events: none;
-			transition: all 0.15s linear;
-			margin-top: 10px;
-			width: 88vw;
+		@media (max-width: #{ ($break-large - 1) }) {
+			grid-row: 2;
+			grid-column: 1;
+			margin-top: 0.25em;
 		}
+	}
+
+	&::before {
+		order: 3;
+		// Offset by the width of the square and the extra space to the corner point.
+		// Add back in the border width to prevent the end poking out under the arrow.
+		margin-left: calc(#{($arrow_size * -1) - ($half_hyp - math.div($arrow-size, 2))} + var(--wporg--style--with-arrow--border-size));
+		height: $arrow_size;
+		min-width: $arrow_size;
+		max-width: $arrow_size;
+		border-top: var(--wporg--style--with-arrow--border-size) solid currentColor;
+		border-right: var(--wporg--style--with-arrow--border-size) solid currentColor;
+		transform: rotate(45deg);
+		transform-origin: center;
+
+		@media (max-width: #{ ($break-large - 1) }) {
+			// Use a smaller arrow on small screens.
+			$arrow_size: 0.5em;
+			$half_hyp: math.div(($arrow_size * $sqrt_2), 2);
+
+			margin-left: 0;
+			justify-self: end;
+			position: relative;
+			// Since this is Sass, not custom properties, the properties also need to be set again.
+			left: calc(#{($half_hyp - math.div($arrow-size, 2)) * -1} + var(--wporg--style--with-arrow--border-size));
+			height: $arrow_size;
+			min-width: $arrow_size;
+			max-width: $arrow_size;
+		}
+	}
+
+	&::after {
+		flex: 1;
+		margin-left: math.div($arrow_size, 2);
+		height: var(--wporg--style--with-arrow--border-size);
+		width: 100%;
+		min-width: 30vw;
+		background: currentColor;
+
+		// Fix issue in GB, where ::after is absolutely positioned.
+		.editor-styles-wrapper & {
+			position: revert !important;
+		}
+
+		@media (max-width: #{ ($break-large - 1) }) {
+			margin-left: 0;
+		}
+	}
+
+	a[href] {
+		text-decoration: none;
+		text-decoration-line: none;
 
 		&:hover,
 		&:focus {
 			text-decoration-line: underline;
 			text-decoration-thickness: 1px;
 			text-underline-offset: 0.15em;
+		}
+	}
 
-			&::after {
-				transform: translateX(10px);
-			}
+	&:hover,
+	&:focus-within {
+		&::before {
+			transform: translateX(#{math.div($arrow_size, 2)}) rotate(45deg);
 		}
 
-		@include break-small() {
-			&::after {
-				width: max(62vw, 100%);
-			}
-		}
-
-		@include break-xlarge() {
-			flex-direction: row;
-			align-items: center;
-
-			&::after {
-				height: 118px;
-				width: 35vw;
-				margin-left: 40px;
-				margin-top: 0;
-				transform: scale(0.9);
-			}
-
-			&:hover,
-			&:focus-within {
-				&::after {
-					transform: scale(0.9) translateX(10px);
-				}
-			}
+		&::after {
+			transform: translateX(#{math.div($arrow_size, 2)});
 		}
 	}
 }

--- a/source/wp-content/themes/wporg-parent-2021/sass/block-styles.scss
+++ b/source/wp-content/themes/wporg-parent-2021/sass/block-styles.scss
@@ -291,7 +291,7 @@
 	&::after {
 		height: var(--wporg--style--with-arrow--border-size);
 		width: 100%;
-		min-width: 30vw;
+		min-width: 3em;
 		background: currentColor;
 
 		// Fix issue in GB, where ::after is absolutely positioned.


### PR DESCRIPTION
Fixes #32, fixes #35. This tries to add a block style for the "with arrow" heading, so we can add it in the editor without needing a special CSS class. I've also tried creating it with just CSS, so that it can reflect the heading text color, in case it's needed in other color schemes.

This fixes the alignment on mid-sized screens by dropping down to the 2nd line at 960px. This seemed to be a natural place to drop off when the text is so large.

The hover color noted in #35 is gone here — the underline for links should be enough visual feedback.

### Screenshots

| Editor | Frontend | Small Screen |
|--------|-------|-------|
| ![Screen Shot 2022-08-05 at 16 38 13](https://user-images.githubusercontent.com/541093/183185653-d30775be-3d43-4385-acb5-d584f76b1cf1.png) | ![Screen Shot 2022-08-05 at 16 38 16](https://user-images.githubusercontent.com/541093/183185697-d1dedaf6-e70c-4ba6-9897-8a00ecc8afa7.png) | ![Screen Shot 2022-08-05 at 16 39 07](https://user-images.githubusercontent.com/541093/183185720-9f0007ca-e6cc-40de-8681-64a3cd0bff34.png) |

https://user-images.githubusercontent.com/541093/183195283-f29c0ac3-6884-4d80-9a5c-7308b43ad768.mp4

https://user-images.githubusercontent.com/541093/183195302-85e4c36e-9456-47c3-85e8-dc44b1091fb1.mp4

### How to test the changes in this Pull Request:

1. Add a heading block to a page
2. Switch to the With Arrow style
3. It should render the arrow in the editor
4. Save it, and view the frontend, you should see the same on the frontend
5. Back in the editor, try different heading levels, adjust the settings in the block UI, it should all work

Test with the pattern too:

1. Add the "Heading with arrow" pattern
2. It should add a blue box with white text
3. Edit the content in the pattern, it should behave as expected
