### PR TITLE
Theme: Use clamp for responsive sizes for more spacing presets

### DIFF
--- a/source/wp-content/themes/wporg-parent-2021/theme.json
+++ b/source/wp-content/themes/wporg-parent-2021/theme.json
@@ -487,7 +487,7 @@
 				{
 					"name": "Large",
 					"slug": 60,
-					"size": "clamp( 24px, calc( 100vw / 18 ), 80px )"
+					"size": "clamp( 20px, calc( 100vw / 18 ), 80px )"
 				},
 				{
 					"name": "X-Large",
@@ -497,12 +497,12 @@
 				{
 					"name": "2X-Large",
 					"slug": 80,
-					"size": "120px"
+					"size": "clamp( 80px, calc( 100vw / 7 ), 120px )"
 				},
 				{
 					"name": "3X-Large",
 					"slug": 90,
-					"size": "160px"
+					"size": "clamp( 80px, calc( 100vw / 7 ), 160px )"
 				}
 			]
 		},


### PR DESCRIPTION
See https://github.com/WordPress/wporg-main-2022/issues/12.

This updates the spacing values to use `clamp` to create sliding spacing values from min to max. The min & max were grabbed from the Figma, but the scaling values were done by eye.

This will be used in the editor (once the UI is there), and in the CSS for the main theme in a PR on that repo.