### PR TITLE
Fix: WordPress.org style improvements

### DIFF
--- a/source/wp-content/themes/wporg-parent-2021/inc/block-styles.php
+++ b/source/wp-content/themes/wporg-parent-2021/inc/block-styles.php
@@ -102,6 +102,15 @@ function setup_block_styles() {
 			'style_handle' => STYLE_HANDLE,
 		)
 	);
+
+	register_block_style(
+		'core/paragraph',
+		array(
+			'name'         => 'short-text',
+			'label'        => __( 'Short text', 'wporg' ),
+			'style_handle' => STYLE_HANDLE,
+		)
+	);
 }
 
 /**

--- a/source/wp-content/themes/wporg-parent-2021/sass/base/_normalize.scss
+++ b/source/wp-content/themes/wporg-parent-2021/sass/base/_normalize.scss
@@ -34,8 +34,8 @@ body[class] {
 
 	// Adjust button padding on small screens.
 	@include break-small-only() {
-		--wp--custom--button--spacing--padding--top: 24px;
-		--wp--custom--button--spacing--padding--bottom: 24px;
+		--wp--custom--button--spacing--padding--top: 23px;
+		--wp--custom--button--spacing--padding--bottom: 23px;
 		--wp--custom--button--spacing--padding--left: 30px;
 		--wp--custom--button--spacing--padding--right: 30px;
 

--- a/source/wp-content/themes/wporg-parent-2021/sass/block-styles.scss
+++ b/source/wp-content/themes/wporg-parent-2021/sass/block-styles.scss
@@ -218,8 +218,7 @@
 }
 
 .is-style-short-text {
-	// 26px / --wp--preset--font-size--normal
-	line-height: 1.625;
+	line-height: var(--wp--custom--body--short-text--typography--line-height);
 }
 
 .wporg-pattern__heading-with-arrow {

--- a/source/wp-content/themes/wporg-parent-2021/sass/block-styles.scss
+++ b/source/wp-content/themes/wporg-parent-2021/sass/block-styles.scss
@@ -217,6 +217,11 @@
 	line-height: var(--wp--custom--heading--level-5--typography--line-height);
 }
 
+.is-style-short-text {
+	// 26px / --wp--preset--font-size--normal
+	line-height: 1.625;
+}
+
 .wporg-pattern__heading-with-arrow {
 	display: flex;
 	flex-direction: row;

--- a/source/wp-content/themes/wporg-parent-2021/theme.json
+++ b/source/wp-content/themes/wporg-parent-2021/theme.json
@@ -183,8 +183,8 @@
 				},
 				"typography": {
 					"fontSize": "var(--wp--preset--font-size--normal)",
-					"fontWeight": "normal",
-					"lineHeight": 2
+					"fontWeight": "600",
+					"lineHeight": 1
 				}
 			},
 			"form": {

--- a/source/wp-content/themes/wporg-parent-2021/theme.json
+++ b/source/wp-content/themes/wporg-parent-2021/theme.json
@@ -214,6 +214,11 @@
 				"typography": {
 					"lineHeight": 1.875
 				},
+				"short-text": {
+					"typography": {
+						"lineHeight": 1.625
+					}
+				},
 				"extra-small": {
 					"typography": {
 						"lineHeight": 1.67


### PR DESCRIPTION
Fixes https://github.com/WordPress/wporg-main-2022/issues/57

Minor style improvements for paragraphs and buttons:
- Buttons heights should be 50px on desktop and 64px on mobile.
- Button font weight should be 600 (see [Figma](https://www.figma.com/file/WHhRwVc4swYnPKdyVWj3du/Home-%26-Download-Pages?node-id=970%3A11414))
- A 'Small text' option has been added to the Paragraph block which reduces the line height from 30px to 26px.

### Screenshots

## Buttons

| Before | After |
|--------|-------|
| ![Screen Shot 2022-08-09 at 4 01 23 PM](https://user-images.githubusercontent.com/1017872/183561559-d501a60c-c542-4f96-a6b5-3a1869615956.jpg) | ![Screen Shot 2022-08-09 at 4 17 40 PM](https://user-images.githubusercontent.com/1017872/183563167-2a1dce79-2e6b-4f12-9f10-c6a6951fbbcf.jpg) |
| ![Screen Shot 2022-08-09 at 4 02 03 PM](https://user-images.githubusercontent.com/1017872/183561650-b969bc92-d94f-4c07-a7f8-a15e9d6a7018.jpg) | ![Screen Shot 2022-08-09 at 4 18 15 PM](https://user-images.githubusercontent.com/1017872/183563206-1fb29965-685b-4075-98fa-e572519d9377.jpg) |

## Paragraph Short Text

| Editor | Frontend |
|--------|-------|
| ![Screen Shot 2022-08-09 at 4 13 35 PM](https://user-images.githubusercontent.com/1017872/183562841-c510ab4a-f7f4-466a-98ad-d10e1b75e848.jpg) | ![Screen Shot 2022-08-09 at 4 14 28 PM](https://user-images.githubusercontent.com/1017872/183562881-e217a009-b6b0-4b70-aed2-57169d28de47.jpg) |


### How to test the changes in this Pull Request:

1. Build the styles
2. Add buttons and a paragraph to a page in the editor
3. Ensure a 'Short text' option is available for the paragraph
4. Select 'Short text'
5. In the frontend verify the buttons are 50px high on desktop, and 64px high on mobile
6. Verify the font weight for the buttons is 600
7. Verify the 'Small text' paragraph line height is 26px, and other standard paragraphs still have 30px