### PR TITLE
Block Style: Add a "Dots" navigation block style

### DIFF
--- a/source/wp-content/themes/wporg-parent-2021/inc/block-styles.php
+++ b/source/wp-content/themes/wporg-parent-2021/inc/block-styles.php
@@ -121,6 +121,15 @@ function setup_block_styles() {
 			'style_handle' => STYLE_HANDLE,
 		)
 	);
+
+	register_block_style(
+		'core/navigation',
+		array(
+			'name'         => 'dots',
+			'label'        => __( 'Dots', 'wporg' ),
+			'style_handle' => STYLE_HANDLE,
+		)
+	);
 }
 
 /**

--- a/source/wp-content/themes/wporg-parent-2021/sass/block-styles.scss
+++ b/source/wp-content/themes/wporg-parent-2021/sass/block-styles.scss
@@ -328,16 +328,20 @@
 	}
 }
 
-.wp-block-navigation.is-style-dots > .wp-block-navigation__container > .wp-block-navigation-item {
-	&::after {
-		content: "·";
-		color: var(--wp--preset--color--charcoal-4);
-		width: 1em;
-		text-align: center;
-		position: relative;
-	}
+.wp-block-navigation.is-style-dots {
+	.wp-block-navigation-item {
+		&::after {
+			content: "·";
+			color: var(--wp--preset--color--charcoal-4);
+			width: 1em;
+			text-align: center;
+			position: relative;
+		}
 
-	&:last-of-type::after {
-		content: "";
+		&.wp-block-navigation-submenu::after,
+		.wp-block-navigation-item::after,
+		&:last-of-type::after {
+			content: "";
+		}
 	}
 }

--- a/source/wp-content/themes/wporg-parent-2021/sass/block-styles.scss
+++ b/source/wp-content/themes/wporg-parent-2021/sass/block-styles.scss
@@ -327,3 +327,17 @@
 		}
 	}
 }
+
+.wp-block-navigation.is-style-dots .wp-block-navigation-item {
+	&::after {
+		content: "·";
+		color: var(--wp--preset--color--charcoal-4);
+		width: 1em;
+		text-align: center;
+		position: relative;
+	}
+
+	&:last-of-type::after {
+		content: "";
+	}
+}

--- a/source/wp-content/themes/wporg-parent-2021/sass/block-styles.scss
+++ b/source/wp-content/themes/wporg-parent-2021/sass/block-styles.scss
@@ -352,4 +352,11 @@
 	.has-modal-open .wp-block-navigation-item::after {
 		content: "";
 	}
+
+	// The dots should default to charcoal-4, but if there is a custom color, use that.
+	&.has-text-color .wp-block-navigation-item::after,
+	.has-text-color & .wp-block-navigation-item::after {
+		color: inherit;
+		opacity: 0.5;
+	}
 }

--- a/source/wp-content/themes/wporg-parent-2021/sass/block-styles.scss
+++ b/source/wp-content/themes/wporg-parent-2021/sass/block-styles.scss
@@ -329,6 +329,9 @@
 }
 
 .wp-block-navigation.is-style-dots {
+	// Remove the gap, since the dots function as spacing.
+	gap: 0;
+
 	.wp-block-navigation-item {
 		&::after {
 			content: "·";

--- a/source/wp-content/themes/wporg-parent-2021/sass/block-styles.scss
+++ b/source/wp-content/themes/wporg-parent-2021/sass/block-styles.scss
@@ -347,4 +347,9 @@
 			content: "";
 		}
 	}
+
+	// Remove the dots from the mobile menu.
+	.has-modal-open .wp-block-navigation-item::after {
+		content: "";
+	}
 }

--- a/source/wp-content/themes/wporg-parent-2021/sass/block-styles.scss
+++ b/source/wp-content/themes/wporg-parent-2021/sass/block-styles.scss
@@ -328,7 +328,7 @@
 	}
 }
 
-.wp-block-navigation.is-style-dots .wp-block-navigation-item {
+.wp-block-navigation.is-style-dots > .wp-block-navigation__container > .wp-block-navigation-item {
 	&::after {
 		content: "·";
 		color: var(--wp--preset--color--charcoal-4);

--- a/source/wp-content/themes/wporg-parent-2021/sass/blocks/_index.scss
+++ b/source/wp-content/themes/wporg-parent-2021/sass/blocks/_index.scss
@@ -3,6 +3,7 @@
 @import "columns";
 @import "file";
 @import "list";
+@import "navigation";
 @import "paragraph";
 @import "post-excerpt";
 @import "post-navigation-link";

--- a/source/wp-content/themes/wporg-parent-2021/sass/blocks/_navigation.scss
+++ b/source/wp-content/themes/wporg-parent-2021/sass/blocks/_navigation.scss
@@ -1,0 +1,11 @@
+// Increase specificity of core selector, to override when it's used in post content.
+.wp-block-navigation:not([class*="has-text-decoration"]) a {
+	text-decoration: none;
+	text-decoration-thickness: 1px;
+	text-underline-offset: 0.15em;
+
+	&:hover,
+	&:focus {
+		text-decoration-line: underline;
+	}
+}

--- a/source/wp-content/themes/wporg-parent-2021/sass/blocks/_navigation.scss
+++ b/source/wp-content/themes/wporg-parent-2021/sass/blocks/_navigation.scss
@@ -1,11 +1,13 @@
-// Increase specificity of core selector, to override when it's used in post content.
-.wp-block-navigation:not([class*="has-text-decoration"]) a {
-	text-decoration: none;
-	text-decoration-thickness: 1px;
-	text-underline-offset: 0.15em;
+.wp-block-navigation {
+	// Increase specificity of core selector, to override when it's used in post content.
+	&:not([class*="has-text-decoration"]) a {
+		text-decoration: none;
+		text-decoration-thickness: 1px;
+		text-underline-offset: 0.15em;
 
-	&:hover,
-	&:focus {
-		text-decoration-line: underline;
+		&:hover,
+		&:focus {
+			text-decoration-line: underline;
+		}
 	}
 }

--- a/source/wp-content/themes/wporg-parent-2021/sass/editor.scss
+++ b/source/wp-content/themes/wporg-parent-2021/sass/editor.scss
@@ -3,6 +3,7 @@
  */
 @import "base/breakpoints";
 @import "blocks/button";
+@import "blocks/navigation";
 
 .wp-block-post-template {
 	width: 100%;

--- a/source/wp-content/themes/wporg-parent-2021/theme.json
+++ b/source/wp-content/themes/wporg-parent-2021/theme.json
@@ -625,9 +625,6 @@
 				}
 			},
 			"core/navigation": {
-				"color": {
-					"text": "var(--wp--custom--link--color--text)"
-				},
 				"typography": {
 					"fontSize": "var(--wp--preset--font-size--normal)"
 				}

--- a/source/wp-content/themes/wporg-parent-2021/theme.json
+++ b/source/wp-content/themes/wporg-parent-2021/theme.json
@@ -625,6 +625,9 @@
 				}
 			},
 			"core/navigation": {
+				"color": {
+					"text": "var(--wp--custom--link--color--text)"
+				},
 				"typography": {
 					"fontSize": "var(--wp--preset--font-size--normal)"
 				}


### PR DESCRIPTION
Fixes https://github.com/WordPress/wporg-main-2022/issues/94 — this updates the default navigation styles, and adds a new block style called "Dots." The updates to the default styles just ensures that the navigation uses the right underline style. The Dots style adds separator dots between top-level menu items.

Edit: I removed the default color, because it conflicted with the global header link colors. I didn't re-take the screenshots, so when testing, these links will be black (unless you set a text color).

Edit 2: The dots style now also removes the block gap, since the dots function as block spacers.

### Screenshots

| Editor | Frontend |
|--------|-------|
| <img width="410" alt="" src="https://user-images.githubusercontent.com/541093/185216036-57cadb15-2a4c-402a-8f78-8476f03bc340.png"> | <img width="430" alt="" src="https://user-images.githubusercontent.com/541093/185216034-9e10ff0e-8db6-4783-ae47-68f14ced68b9.png"> |

### How to test the changes in this Pull Request:

1. Add a navigation menu to a page
2. The links should not be underlined by default, and underline on hover
3. Try the dots style
4. There should now be grey dots separating the links
