### PR TITLE
Make CTA heading arrow clickable

### DIFF
--- a/source/wp-content/themes/wporg-parent-2021/inc/block-styles.php
+++ b/source/wp-content/themes/wporg-parent-2021/inc/block-styles.php
@@ -117,7 +117,7 @@ function setup_block_styles() {
 		'core/heading',
 		array(
 			'name'         => 'with-arrow',
-			'label'        => __( 'CTA', 'wporg' ),
+			'label'        => __( 'Link arrow', 'wporg' ),
 			'style_handle' => STYLE_HANDLE,
 		)
 	);

--- a/source/wp-content/themes/wporg-parent-2021/inc/block-styles.php
+++ b/source/wp-content/themes/wporg-parent-2021/inc/block-styles.php
@@ -117,7 +117,7 @@ function setup_block_styles() {
 		'core/heading',
 		array(
 			'name'         => 'with-arrow',
-			'label'        => __( 'Link arrow', 'wporg' ),
+			'label'        => __( 'Link & Arrow', 'wporg' ),
 			'style_handle' => STYLE_HANDLE,
 		)
 	);

--- a/source/wp-content/themes/wporg-parent-2021/inc/block-styles.php
+++ b/source/wp-content/themes/wporg-parent-2021/inc/block-styles.php
@@ -117,7 +117,7 @@ function setup_block_styles() {
 		'core/heading',
 		array(
 			'name'         => 'with-arrow',
-			'label'        => __( 'With Arrow', 'wporg' ),
+			'label'        => __( 'CTA', 'wporg' ),
 			'style_handle' => STYLE_HANDLE,
 		)
 	);

--- a/source/wp-content/themes/wporg-parent-2021/sass/block-styles.scss
+++ b/source/wp-content/themes/wporg-parent-2021/sass/block-styles.scss
@@ -248,13 +248,6 @@
 		gap: 0.5em;
 	}
 
-	&:hover,
-	&:focus {
-		text-decoration-line: underline;
-		text-decoration-thickness: 1px;
-		text-underline-offset: 0.15em;
-	}
-
 	&::before,
 	&::after {
 		content: "";
@@ -314,7 +307,12 @@
 	}
 
 	&:hover,
+	&:focus,
 	&:focus-within {
+		text-decoration-line: underline;
+		text-decoration-thickness: 1px;
+		text-underline-offset: 0.15em;
+		
 		&::before {
 			transform: translateX(#{math.div($arrow_size, 2)}) rotate(45deg);
 		}

--- a/source/wp-content/themes/wporg-parent-2021/sass/block-styles.scss
+++ b/source/wp-content/themes/wporg-parent-2021/sass/block-styles.scss
@@ -222,7 +222,7 @@
 	line-height: var(--wp--custom--body--short-text--typography--line-height);
 }
 
-.is-style-with-arrow a[href] {
+.is-style-with-arrow a[href]:first-of-type {
 	// Note, these are Sass variables to make the math easier. While we could do
 	// this with `calc()`s, it would be even more unruly.
 	$arrow_size: 1em;

--- a/source/wp-content/themes/wporg-parent-2021/sass/block-styles.scss
+++ b/source/wp-content/themes/wporg-parent-2021/sass/block-styles.scss
@@ -222,7 +222,7 @@
 	line-height: var(--wp--custom--body--short-text--typography--line-height);
 }
 
-.is-style-with-arrow {
+.is-style-with-arrow a[href] {
 	// Note, these are Sass variables to make the math easier. While we could do
 	// this with `calc()`s, it would be even more unruly.
 	$arrow_size: 1em;
@@ -236,6 +236,8 @@
 	--wporg--style--with-arrow--border-size: 1px;
 
 	position: relative;
+	text-decoration: none;
+	text-decoration-line: none;
 	display: grid;
 	align-items: center;
 	grid-template-columns: auto;
@@ -244,6 +246,13 @@
 	@include break-large() {
 		grid-template-columns: auto 1fr;
 		gap: 0.5em;
+	}
+
+	&:hover,
+	&:focus {
+		text-decoration-line: underline;
+		text-decoration-thickness: 1px;
+		text-underline-offset: 0.15em;
 	}
 
 	&::before,
@@ -301,18 +310,6 @@
 
 		@media (max-width: #{ ($break-large - 1) }) {
 			margin-left: 0;
-		}
-	}
-
-	a[href] {
-		text-decoration: none;
-		text-decoration-line: none;
-
-		&:hover,
-		&:focus {
-			text-decoration-line: underline;
-			text-decoration-thickness: 1px;
-			text-underline-offset: 0.15em;
 		}
 	}
 


### PR DESCRIPTION
Fixes #40 by applying the arrow style to the anchor within the heading tag, enabling it to be clicked. As mentioned in the ticket this assumes that this style of heading will always be a call to action and hence have a link applied.

### Screenshots

| Editor | FE Desktop | FE Small
|--------|--------|--------|
| ![Screen Shot 2022-08-22 at 1 53 44 PM](https://user-images.githubusercontent.com/1017872/185825209-941ff787-b740-4ca9-b37d-e6d5c5b413d3.jpg) | ![Screen Shot 2022-08-22 at 1 54 00 PM](https://user-images.githubusercontent.com/1017872/185825246-7f3c3e96-9be7-4c10-8688-043450b889c3.jpg) | ![Screen Shot 2022-08-22 at 1 54 18 PM](https://user-images.githubusercontent.com/1017872/185825270-0a9cb056-74fe-45a4-952c-a060b3d950dd.jpg) |

### How to test the changes in this Pull Request:

1. Add a heading to a post or page
2. Select the CTA option
3. Observe that no arrow appears
4. Add a link to the heading text
5. Observe that the arrow style is applied