### PR TITLE
Make style of 'Link & arrow' heading in Firefox editor match frontend

### DIFF
--- a/source/wp-content/themes/wporg-parent-2021/sass/blocks/_heading.scss
+++ b/source/wp-content/themes/wporg-parent-2021/sass/blocks/_heading.scss
@@ -1,0 +1,5 @@
+.wp-block-heading {
+	&.is-style-with-arrow {
+		white-space: revert !important;
+	}
+}

--- a/source/wp-content/themes/wporg-parent-2021/sass/blocks/_heading.scss
+++ b/source/wp-content/themes/wporg-parent-2021/sass/blocks/_heading.scss
@@ -1,5 +1,0 @@
-.wp-block-heading {
-	&.is-style-with-arrow {
-		white-space: revert !important;
-	}
-}

--- a/source/wp-content/themes/wporg-parent-2021/sass/editor.scss
+++ b/source/wp-content/themes/wporg-parent-2021/sass/editor.scss
@@ -3,7 +3,6 @@
  */
 @import "base/breakpoints";
 @import "blocks/button";
-@import "blocks/heading";
 @import "blocks/navigation";
 
 .wp-block-post-template {
@@ -23,4 +22,8 @@
 // Overwrite a style from wp4.css.
 h3 a {
 	font-weight: revert; // stylelint-disable-line font-weight-notation
+}
+
+.wp-block-heading.is-style-with-arrow {
+	white-space: revert !important;
 }

--- a/source/wp-content/themes/wporg-parent-2021/sass/editor.scss
+++ b/source/wp-content/themes/wporg-parent-2021/sass/editor.scss
@@ -3,6 +3,7 @@
  */
 @import "base/breakpoints";
 @import "blocks/button";
+@import "blocks/heading";
 @import "blocks/navigation";
 
 .wp-block-post-template {


### PR DESCRIPTION
Fixes #40 by overriding inline styles added by editor causing extra space under heading blocks with the option 'Link & arrow'.

Props @ryelle 

### Screenshots

#### Frontend (note no space under heading and no single space before CTA on the bottom multiline version)

![Screen Shot 2022-08-24 at 10 49 15 AM](https://user-images.githubusercontent.com/1017872/186279653-ed01cce5-db15-4253-bac1-44b37461abc7.jpg)

#### Editor

| Before | After |
|--------|-------|
| ![Screen Shot 2022-08-24 at 10 47 48 AM](https://user-images.githubusercontent.com/1017872/186279683-8ceb6094-973e-4123-8293-5a9e41b701e9.jpg) | ![Screen Shot 2022-08-24 at 10 48 54 AM](https://user-images.githubusercontent.com/1017872/186279709-3bb4aee6-b01e-478e-a6c8-04ccb28ee956.jpg) |

### How to test the changes in this Pull Request:

1. Open the editor in Firefox
2. Create a post and add a heading block
3. Below the heading add any other block
4. Choose the 'Link & arrow' option
5. There shouldn't be excessive space below the heading
6. Check that the display in the editor matches the frontend
7. Check other supported browsers