### PR TITLE
Add post-navigation pattern

### DIFF
--- a/source/wp-content/themes/wporg-parent-2021/patterns/post-navigation.php
+++ b/source/wp-content/themes/wporg-parent-2021/patterns/post-navigation.php
@@ -8,17 +8,7 @@
 ?>
 
 <!-- wp:group {"style":{"border":{"top":{"color":"var:preset|color|light-grey-1","width":"1px"}},"spacing":{"padding":{"top":"var:preset|spacing|20","right":"var:preset|spacing|20","bottom":"var:preset|spacing|20","left":"var:preset|spacing|20"}}},"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between"}} -->
-<div
-	class="wp-block-group"
-	style="
-		border-top-color: var( --wp--preset--color--light-grey-1 );
-		border-top-width: 1px;
-		padding-top: var( --wp--preset--spacing--20 );
-		padding-right: var( --wp--preset--spacing--20 );
-		padding-bottom: var( --wp--preset--spacing--20 );
-		padding-left: var( --wp--preset--spacing--20 );
-	"
->
+<div class="wp-block-group" style="border-top-color:var(--wp--preset--color--light-grey-1);border-top-width:1px;padding-top:var(--wp--preset--spacing--20);padding-right:var(--wp--preset--spacing--20);padding-bottom:var(--wp--preset--spacing--20);padding-left:var(--wp--preset--spacing--20)">
 	<!-- wp:post-navigation-link {"type":"previous","showTitle":true,"label":"<?php esc_attr_e( 'Previous', 'wporg' ); ?>","linkLabel":true} /-->
 	<!-- wp:post-navigation-link {"type":"next","showTitle":true,"label":"<?php esc_attr_e( 'Next', 'wporg' ); ?>","linkLabel":true} /-->
 </div>

--- a/source/wp-content/themes/wporg-parent-2021/patterns/post-navigation.php
+++ b/source/wp-content/themes/wporg-parent-2021/patterns/post-navigation.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Title: Post Navigation
+ * Slug: wporg-parent-2021/post-navigation
+ * Inserter: no
+ */
+
+?>
+
+<!-- wp:group {"style":{"border":{"top":{"color":"var:preset|color|light-grey-1","width":"1px"}},"spacing":{"padding":{"top":"var:preset|spacing|20","right":"var:preset|spacing|20","bottom":"var:preset|spacing|20","left":"var:preset|spacing|20"}}},"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between"}} -->
+<div
+	class="wp-block-group"
+	style="
+		border-top-color: var( --wp--preset--color--light-grey-1 );
+		border-top-width: 1px;
+		padding-top: var( --wp--preset--spacing--20 );
+		padding-right: var( --wp--preset--spacing--20 );
+		padding-bottom: var( --wp--preset--spacing--20 );
+		padding-left: var( --wp--preset--spacing--20 );
+	"
+>
+	<!-- wp:post-navigation-link {"type":"previous","showTitle":true,"label":"<?php _e( 'Previous', 'wporg' ); ?>","linkLabel":true} /-->
+	<!-- wp:post-navigation-link {"type":"next","showTitle":true,"label":"<?php _e( 'Next', 'wporg' ); ?>","linkLabel":true} /-->
+</div>
+<!-- /wp:group -->

--- a/source/wp-content/themes/wporg-parent-2021/patterns/post-navigation.php
+++ b/source/wp-content/themes/wporg-parent-2021/patterns/post-navigation.php
@@ -2,7 +2,7 @@
 /**
  * Title: Post Navigation
  * Slug: wporg-parent-2021/post-navigation
- * Inserter: no
+ * Category: wporg
  */
 
 ?>

--- a/source/wp-content/themes/wporg-parent-2021/patterns/post-navigation.php
+++ b/source/wp-content/themes/wporg-parent-2021/patterns/post-navigation.php
@@ -19,7 +19,7 @@
 		padding-left: var( --wp--preset--spacing--20 );
 	"
 >
-	<!-- wp:post-navigation-link {"type":"previous","showTitle":true,"label":"<?php _e( 'Previous', 'wporg' ); ?>","linkLabel":true} /-->
-	<!-- wp:post-navigation-link {"type":"next","showTitle":true,"label":"<?php _e( 'Next', 'wporg' ); ?>","linkLabel":true} /-->
+	<!-- wp:post-navigation-link {"type":"previous","showTitle":true,"label":"<?php esc_attr_e( 'Previous', 'wporg' ); ?>","linkLabel":true} /-->
+	<!-- wp:post-navigation-link {"type":"next","showTitle":true,"label":"<?php esc_attr_e( 'Next', 'wporg' ); ?>","linkLabel":true} /-->
 </div>
 <!-- /wp:group -->


### PR DESCRIPTION
This PR adds a pattern for navigating to previous/next posts. I am adding this pattern here because it now shows up in 2 themes, `wporg-showcase-2022` ([Showcase example](https://www.figma.com/file/nK6LcMOZMtRAQdIky3PNIA/Showcase-Pages?node-id=656%3A12482)), and `wporg-news-2021` ([News Site Example](https://wordpress.org/news/2022/10/wordpress-6-0-3-security-release/)).

See https://github.com/WordPress/wporg-showcase-2022/issues/6

### Screenshots

Disregard the page layout, it's an incomplete part of WordPress/wporg-showcase-2022.

| Desktop |  Table | Mobile |
|--------|-------|-------| 
|  <img width="1188" alt="Screen Shot 2022-10-25 at 1 58 17 PM" src="https://user-images.githubusercontent.com/1657336/197687513-cb2959fa-ebbb-42dc-9ec7-b5ba828e0ae8.png"> | <img width="726" alt="Screen Shot 2022-10-25 at 1 58 23 PM" src="https://user-images.githubusercontent.com/1657336/197687519-9ea019e0-5f44-4083-a8df-3c177df17f19.png"> | <img width="356" alt="Screen Shot 2022-10-25 at 1 58 37 PM" src="https://user-images.githubusercontent.com/1657336/197687525-9d7a5fad-ceb8-48fb-b576-430bbdaaf2c6.png">

### How to test the changes in this Pull Request:

1. Ensure you have multiple posts.
2. Add `<!-- wp:pattern {"slug":"wporg-parent-2021/post-navigation"} /-->` to a single post view


# Notes
- It includes inline CSS styles which were copied directly out of the block editor. I'm not sure if that's the best approach. 🤔 
- In wporg-main-2021, the wrapper container is a `nav` tag. Since this is using default block editor styles, the `<Row>` component doesn't allow for that selection. I could wrap the group with a nav for semantics sake. Alternatively i can stop relying on the default block editor built styles. **Thoughts**?