### PR TITLE
Add dark chevrons when navigation has white background.

### DIFF
--- a/source/wp-content/themes/wporg-parent-2021/images/down-chevron-blueberry.svg
+++ b/source/wp-content/themes/wporg-parent-2021/images/down-chevron-blueberry.svg
@@ -1,0 +1,3 @@
+<svg width="12" height="7" viewBox="0 0 12 7" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M1.417 1.333 6.001 5.5l4.583-4.167" stroke="#3858e9" stroke-width="1.4"/>
+</svg>

--- a/source/wp-content/themes/wporg-parent-2021/images/down-chevron-dark.svg
+++ b/source/wp-content/themes/wporg-parent-2021/images/down-chevron-dark.svg
@@ -1,0 +1,3 @@
+<svg width="12" height="7" viewBox="0 0 12 7" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M1.417 1.333 6.001 5.5l4.583-4.167" stroke="#fff" stroke-width="1.4"/>
+</svg>

--- a/source/wp-content/themes/wporg-parent-2021/images/down-chevron-dark.svg
+++ b/source/wp-content/themes/wporg-parent-2021/images/down-chevron-dark.svg
@@ -1,3 +1,3 @@
 <svg width="12" height="7" viewBox="0 0 12 7" fill="none" xmlns="http://www.w3.org/2000/svg">
-  <path d="M1.417 1.333 6.001 5.5l4.583-4.167" stroke="#fff" stroke-width="1.4"/>
+  <path d="M1.417 1.333 6.001 5.5l4.583-4.167" stroke="#1e1e1e" stroke-width="1.4"/>
 </svg>

--- a/source/wp-content/themes/wporg-parent-2021/images/up-chevron-blueberry.svg
+++ b/source/wp-content/themes/wporg-parent-2021/images/up-chevron-blueberry.svg
@@ -1,0 +1,3 @@
+<svg width="12" height="7" viewBox="0 0 12 7" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M1.417 5.667 6.001 1.5l4.583 4.167" stroke="#3858e9" stroke-width="1.4"/>
+</svg>

--- a/source/wp-content/themes/wporg-parent-2021/images/up-chevron-dark.svg
+++ b/source/wp-content/themes/wporg-parent-2021/images/up-chevron-dark.svg
@@ -1,0 +1,3 @@
+<svg width="12" height="7" viewBox="0 0 12 7" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M1.417 5.667 6.001 1.5l4.583 4.167" stroke="#1e1e1e" stroke-width="1.4"/>
+</svg>

--- a/source/wp-content/themes/wporg-parent-2021/inc/block-styles.php
+++ b/source/wp-content/themes/wporg-parent-2021/inc/block-styles.php
@@ -132,15 +132,6 @@ function setup_block_styles() {
 	);
 
 	register_block_style(
-		'core/navigation',
-		array(
-			'name'         => 'light',
-			'label'        => __( 'Light', 'wporg' ),
-			'style_handle' => STYLE_HANDLE,
-		)
-	);
-
-	register_block_style(
 		'core/group',
 		array(
 			'name'         => 'brush-stroke',

--- a/source/wp-content/themes/wporg-parent-2021/inc/block-styles.php
+++ b/source/wp-content/themes/wporg-parent-2021/inc/block-styles.php
@@ -132,6 +132,15 @@ function setup_block_styles() {
 	);
 
 	register_block_style(
+		'core/navigation',
+		array(
+			'name'         => 'light',
+			'label'        => __( 'Light', 'wporg' ),
+			'style_handle' => STYLE_HANDLE,
+		)
+	);
+
+	register_block_style(
 		'core/group',
 		array(
 			'name'         => 'brush-stroke',

--- a/source/wp-content/themes/wporg-parent-2021/sass/block-styles.scss
+++ b/source/wp-content/themes/wporg-parent-2021/sass/block-styles.scss
@@ -446,15 +446,25 @@
 	}
 }
 
-// Styles for when Navigation background is light.
-.wp-block-navigation.is-style-dropdown-on-mobile.has-white-background-color {
+// Use a dark chevron when the nav text is charcoal-1.
+.wp-block-navigation.is-style-dropdown-on-mobile.has-charcoal-1-color {
 	.wp-block-navigation__responsive-container-open {
 		background-image: url(../images/down-chevron-dark.svg);
 	}
 
-	// .is-menu-open is needed for specificity
-	.is-menu-open .wp-block-navigation__responsive-container-close {
+	.wp-block-navigation__responsive-container.is-menu-open .wp-block-navigation__responsive-container-close {
 		background-image: url(../images/up-chevron-dark.svg);
+	}
+}
+
+// Use a blue chevron when the nav text is blueberry-1.
+.wp-block-navigation.is-style-dropdown-on-mobile.has-blueberry-1-color {
+	.wp-block-navigation__responsive-container-open {
+		background-image: url(../images/down-chevron-blueberry.svg);
+	}
+
+	.wp-block-navigation__responsive-container.is-menu-open .wp-block-navigation__responsive-container-close {
+		background-image: url(../images/up-chevron-blueberry.svg);
 	}
 }
 

--- a/source/wp-content/themes/wporg-parent-2021/sass/block-styles.scss
+++ b/source/wp-content/themes/wporg-parent-2021/sass/block-styles.scss
@@ -356,17 +356,6 @@
 	}
 }
 
-// Styles for when Navigation background is light.
-.wp-block-navigation.is-style-dropdown-on-mobile.is-style-light {
-	.wp-block-navigation__responsive-container-open {
-		background-image: url(../images/down-chevron-dark.svg);
-	}
-
-	.wp-block-navigation__responsive-container-close {
-		background-image: url(../images/down-chevron-dark.svg);
-	}
-}
-
 .is-style-brush-stroke {
 	position: relative;
 
@@ -454,6 +443,17 @@
 				display: none;
 			}
 		}
+	}
+}
+
+// Styles for when Navigation background is light.
+.wp-block-navigation.is-style-dropdown-on-mobile.has-white-background-color {
+	.wp-block-navigation__responsive-container-open {
+		background-image: url(../images/down-chevron-dark.svg);
+	}
+
+	.wp-block-navigation__responsive-container-close {
+		background-image: url(../images/down-chevron-dark.svg);
 	}
 }
 

--- a/source/wp-content/themes/wporg-parent-2021/sass/block-styles.scss
+++ b/source/wp-content/themes/wporg-parent-2021/sass/block-styles.scss
@@ -452,7 +452,7 @@
 		background-image: url(../images/down-chevron-dark.svg);
 	}
 
-	.wp-block-navigation__responsive-container-close {
+	.is-menu-open .wp-block-navigation__responsive-container-close {
 		background-image: url(../images/up-chevron-dark.svg);
 	}
 }

--- a/source/wp-content/themes/wporg-parent-2021/sass/block-styles.scss
+++ b/source/wp-content/themes/wporg-parent-2021/sass/block-styles.scss
@@ -453,7 +453,7 @@
 	}
 
 	.wp-block-navigation__responsive-container-close {
-		background-image: url(../images/down-chevron-dark.svg);
+		background-image: url(../images/up-chevron-dark.svg);
 	}
 }
 

--- a/source/wp-content/themes/wporg-parent-2021/sass/block-styles.scss
+++ b/source/wp-content/themes/wporg-parent-2021/sass/block-styles.scss
@@ -356,6 +356,17 @@
 	}
 }
 
+// Styles for when Navigation background is light.
+.wp-block-navigation.is-style-dropdown-on-mobile.is-style-light {
+	.wp-block-navigation__responsive-container-open {
+		background-image: url(../images/down-chevron-dark.svg);
+	}
+
+	.wp-block-navigation__responsive-container-close {
+		background-image: url(../images/down-chevron-dark.svg);
+	}
+}
+
 .is-style-brush-stroke {
 	position: relative;
 

--- a/source/wp-content/themes/wporg-parent-2021/sass/block-styles.scss
+++ b/source/wp-content/themes/wporg-parent-2021/sass/block-styles.scss
@@ -452,6 +452,7 @@
 		background-image: url(../images/down-chevron-dark.svg);
 	}
 
+	// .is-menu-open is needed for specificity
 	.is-menu-open .wp-block-navigation__responsive-container-close {
 		background-image: url(../images/up-chevron-dark.svg);
 	}


### PR DESCRIPTION
This PR adds a dark chevron arrow if the navigation background is white. This is somewhat short-sighted since its styles are based on `has-white-background-color` but I think it's good enough for now. An ideal approach would be to allow authors to change the colors of the chevron svgs.

See https://github.com/WordPress/wporg-showcase-2022/issues/1


### Screenshots
| Before | After |
|--------|-------|
| <img width="493" alt="Screen Shot 2022-10-28 at 10 02 46 AM" src="https://user-images.githubusercontent.com/1657336/198427994-8910afb7-0b6f-41de-8a9a-b4a11a4993e8.png">  | <img width="512" alt="Screen Shot 2022-10-28 at 9 57 11 AM" src="https://user-images.githubusercontent.com/1657336/198428000-439ee3b7-f5be-44d6-964f-1589dd99fc9a.png"> |

### How to test the changes in this Pull Request:

1. Load the [subnav-bar](https://github.com/WordPress/wporg-parent-2021/blob/trunk/source/wp-content/themes/wporg-parent-2021/patterns/subnav-bar.php) pattern.
2. Remove the brush stroke
3. Update the background colors to `#fff`, text to something dark.
4. View the control on a front-end page, and adjust the page to a mobile size
5. Expect to see the down arrow, open/close it.

<!-- If you can, add the appropriate [Component] label(s). -->
