### PR TITLE
Add an external link icon and css style.

### DIFF
--- a/source/wp-content/themes/wporg-parent-2021/images/external-link-icon.svg
+++ b/source/wp-content/themes/wporg-parent-2021/images/external-link-icon.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="48" height="48" aria-hidden="true" focusable="false">
+	<path d="M18.2 17c0 .7-.6 1.2-1.2 1.2H7c-.7 0-1.2-.6-1.2-1.2V7c0-.7.6-1.2 1.2-1.2h3.2V4.2H7C5.5 4.2 4.2 5.5 4.2 7v10c0 1.5 1.2 2.8 2.8 2.8h10c1.5 0 2.8-1.2 2.8-2.8v-3.6h-1.5V17zM14.9 3v1.5h3.7l-6.4 6.4 1.1 1.1 6.4-6.4v3.7h1.5V3h-6.3z"></path>
+</svg>

--- a/source/wp-content/themes/wporg-parent-2021/sass/base/_elements.scss
+++ b/source/wp-content/themes/wporg-parent-2021/sass/base/_elements.scss
@@ -29,7 +29,10 @@ mark.has-inline-color {
 }
 
 // For links that navigate users to different site
-a:not([href*="wordpress.org"])::after {
+a.external-link::after,
+a.external-link-light::after,
+.external-link > a:not([href*="wordpress.org"])::after,
+.external-link-light > a:not([href*="wordpress.org"])::after {
 	content: "";
 	display: inline-flex;
 	background-color: var(--wp--preset--color--charcoal-4);
@@ -39,8 +42,12 @@ a:not([href*="wordpress.org"])::after {
 	vertical-align: middle;
 	-webkit-mask-image: url(../images/external-link-icon.svg);
 	mask-image: url(../images/external-link-icon.svg);
-	-webkit-mask-size: cover;
 	mask-size: cover;
+}
+
+a.external-link-light::after,
+.external-link-light > a:not([href*="wordpress.org"])::after {
+	background-color: var(--wp--preset--color--light-grey-2);
 }
 
 // Inline code tags should use the monospace font.

--- a/source/wp-content/themes/wporg-parent-2021/sass/base/_elements.scss
+++ b/source/wp-content/themes/wporg-parent-2021/sass/base/_elements.scss
@@ -28,6 +28,22 @@ mark.has-inline-color {
 	}
 }
 
+// For links that navigate users to different site
+.external-link > a::after, // In case we don't access to <a> tag
+a.external-link::after {
+	content: "";
+	display: inline-flex;
+	background-color: var(--wp--preset--color--charcoal-4);
+	width: 1em;
+	height: 1em;
+	margin-left: 0.1em;
+	vertical-align: middle;
+	-webkit-mask-image: url(../images/external-link-icon.svg);
+	mask-image: url(../images/external-link-icon.svg);
+	-webkit-mask-size: cover;
+	mask-size: cover;
+}
+
 // Inline code tags should use the monospace font.
 code {
 	font-family: var(--wp--preset--font-family--monospace);

--- a/source/wp-content/themes/wporg-parent-2021/sass/base/_elements.scss
+++ b/source/wp-content/themes/wporg-parent-2021/sass/base/_elements.scss
@@ -40,7 +40,6 @@ a.external-link-light::after,
 	height: 1em;
 	margin-left: 0.1em;
 	vertical-align: middle;
-	-webkit-mask-image: url(../images/external-link-icon.svg);
 	mask-image: url(../images/external-link-icon.svg);
 	mask-size: cover;
 }

--- a/source/wp-content/themes/wporg-parent-2021/sass/base/_elements.scss
+++ b/source/wp-content/themes/wporg-parent-2021/sass/base/_elements.scss
@@ -29,8 +29,7 @@ mark.has-inline-color {
 }
 
 // For links that navigate users to different site
-.external-link > a::after, // In case we don't access to <a> tag
-a.external-link::after {
+a:not([href*="wordpress.org"])::after {
 	content: "";
 	display: inline-flex;
 	background-color: var(--wp--preset--color--charcoal-4);


### PR DESCRIPTION
External links should display an external link icon. This PR adds an `svg`, taken from Gutenberg, and a class to target external links.

I wasn't exactly sure what color to give the icon. I went with a moderately dark grey color from our theme. 

<!-- Reference any related issues or PRs here. Each issue needs the "fixes" keyword if the PR fixes more than one thing. -->
See https://github.com/WordPress/wporg-showcase-2022/issues/42.


### Drawback of this approach
 Since we are only using CSS and not a block or something similar, users cannot see the external icon when viewing the post in the block editor. However, I don't expect there to be many external links, and doing more work should probably be considered only if we receive feedback from teams (maybe the documentation team may find that frustrating for example). 

### Screenshots

<!-- If your change has a visual component, add a screenshot here. -->

| Caption | Screenshot | 
| --- | --- |
|  Default | <img width="200" alt="Screen Shot 2022-11-15 at 9 55 59 AM" src="https://user-images.githubusercontent.com/1657336/201801902-4f8bd782-ac54-48a9-bcfd-33bcd3943300.png"> | 
|  With Element font-size: 40px | <img width="400" alt="Screen Shot 2022-11-15 at 9 55 47 AM" src="https://user-images.githubusercontent.com/1657336/201801908-9538f0e3-234f-471c-94bf-2411ae4b8abe.png"> | 
|  Inline | <img width="662" alt="Screen Shot 2022-11-15 at 10 45 32 AM" src="https://user-images.githubusercontent.com/1657336/201806247-2846a192-1331-4d28-bcdd-b01f84a4e849.png"> | 
|  Alternative color option -- Not Implemented here | <img width="200" alt="Screen Shot 2022-11-15 at 9 56 41 AM" src="https://user-images.githubusercontent.com/1657336/201801898-7e6d71d4-df6a-4223-939a-7b7684a2b9b0.png"> | 



### How to test the changes in this Pull Request:

- Add a link to some post content, add `external-link` class to the element. Expect to the the icon.
- Alternatively, you can add the class to the direct parent of the `<a>` 
  - This is done in case we don't have direct access to the `<a>` element.
