### PR TITLE
Fix dropdown layout broken issue

### DIFF
--- a/source/wp-content/themes/wporg-parent-2021/sass/block-styles.scss
+++ b/source/wp-content/themes/wporg-parent-2021/sass/block-styles.scss
@@ -479,9 +479,10 @@
 }
 
 /**
- * Update the "Dropdown on Mobile" style when the menu is inside a "Brush Stroke" group block.
+ * Update the "Dropdown on Mobile" style when the menu is inside a "Brush Stroke" group block or is sticky.
  */
 
+.is-sticky .is-style-dropdown-on-mobile,
 .is-style-brush-stroke .is-style-dropdown-on-mobile {
 	.wp-block-navigation__responsive-container-open {
 		position: absolute;

--- a/source/wp-content/themes/wporg-parent-2021/sass/block-styles.scss
+++ b/source/wp-content/themes/wporg-parent-2021/sass/block-styles.scss
@@ -358,9 +358,6 @@
 
 .is-style-brush-stroke {
 	position: relative;
-	// Locally override this value to create a fixed breakpoint, rather than the
-	// scaling effect from `clamp(…)`.
-	--wp--preset--spacing--60: 20px;
 
 	&::before {
 		content: "";
@@ -375,26 +372,6 @@
 		mask-size: cover;
 		mask-position: bottom right;
 		background-color: inherit;
-	}
-}
-
-@media (min-width: 890px) {
-	// Only add this for pages with the block on it.
-	html:has(.is-style-brush-stroke.is-sticky) {
-		// 57px is height of the brush-stroke bar.
-		scroll-padding-top: calc(var(--wp-global-header-offset, 0px) + 57px);
-	}
-
-	.is-style-brush-stroke {
-		// When larger than 890px, this should snap to 80px.
-		--wp--preset--spacing--60: 80px;
-	}
-
-	// If the brush-stroke style is the first item, it should be sticky.
-	.is-style-brush-stroke.is-sticky {
-		position: sticky;
-		top: var(--wp-global-header-offset, 0);
-		z-index: 50;
 	}
 }
 
@@ -479,11 +456,37 @@
 }
 
 /**
- * Update the "Dropdown on Mobile" style when the menu is inside a "Brush Stroke" group block or is sticky.
+ * Add support for a "sticky" header by using the `is-sticky` class. At 890px,
+ * this will snap to under the global header, and stay fixed while scrolling.
  */
 
-.is-sticky .is-style-dropdown-on-mobile,
-.is-style-brush-stroke .is-style-dropdown-on-mobile {
+.is-sticky {
+	// Locally override this value to create a fixed breakpoint, rather than the
+	// scaling effect from `clamp(…)`.
+	--wp--preset--spacing--60: 20px;
+}
+
+@media (min-width: 890px) {
+	// Only add this for pages with the block on it.
+	html:has(.is-sticky) {
+		// 57px is height of the sticky bar.
+		scroll-padding-top: calc(var(--wp-global-header-offset, 0px) + 57px);
+	}
+
+	.is-sticky {
+		// When larger than 890px, this should snap to 80px.
+		--wp--preset--spacing--60: 80px;
+		position: sticky;
+		top: var(--wp-global-header-offset, 0);
+		z-index: 50;
+	}
+}
+
+/**
+ * Update the "Dropdown on Mobile" style when the menu is inside a sticky header.
+ */
+
+.is-sticky .is-style-dropdown-on-mobile {
 	.wp-block-navigation__responsive-container-open {
 		position: absolute;
 		right: 0;


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here. Each issue needs the "fixes" keyword if the PR fixes more than one thing. -->
See https://github.com/WordPress/wporg-showcase-2022/pull/64.

<!-- List out anyone who helped with this task. -->


<!-- Don't forget to update the title with something descriptive. -->

### Screenshots
![dropdown](https://user-images.githubusercontent.com/18050944/204387502-359aeecc-5b9b-41c5-8313-e2fa4f7bb699.gif)


### How to test the changes in this Pull Request:

1. Go to random showcase single page
2. Switch to mobile view
3. Test dropdown

<!-- If you can, add the appropriate [Component] label(s). -->
