### PR TITLE
Block Styles: Add the Secondary Search block style on search block

### DIFF
--- a/source/wp-content/themes/wporg-parent-2021/inc/block-styles.php
+++ b/source/wp-content/themes/wporg-parent-2021/inc/block-styles.php
@@ -148,6 +148,15 @@ function setup_block_styles() {
 			'style_handle' => STYLE_HANDLE,
 		)
 	);
+
+	register_block_style(
+		'core/search',
+		array(
+			'name'         => 'secondary-search-control',
+			'label'        => __( 'Secondary', 'wporg' ),
+			'style_handle' => STYLE_HANDLE,
+		)
+	);
 }
 
 /**

--- a/source/wp-content/themes/wporg-parent-2021/sass/block-styles.scss
+++ b/source/wp-content/themes/wporg-parent-2021/sass/block-styles.scss
@@ -518,3 +518,70 @@
 		}
 	}
 }
+
+/**
+ * Secondary Search style
+ */
+
+.is-style-secondary-search-control {
+	// Set the custom properties so hover/focus/etc still work.
+	--wp--custom--button--color--text: var(--wp--preset--color--charcoal-1);
+	--wp--custom--button--color--background: transparent;
+	--wp--custom--button--hover--color--text: var(--wp--preset--color--charcoal-1);
+	--wp--custom--button--hover--color--background: var(--wp--preset--color--light-grey-2);
+	// Set a local custom property so child themes can set this in one place.
+	--local--border-color: var(--wp--preset--color--charcoal-1);
+
+	display: flex;
+	align-items: center;
+
+	> label {
+		flex: 0;
+		font-size: var(--wp--preset--font-size--extra-small);
+		padding-right: var(--wp--preset--spacing--10);
+	}
+
+	input[type="search"] {
+		border: none;
+		font-size: var(--wp--preset--font-size--extra-small);
+		padding: 0 var(--wp--preset--spacing--10) !important;
+	}
+
+	&.wp-block-search__no-button input[type="search"] {
+		min-height: var(--wp--preset--spacing--40);
+		border: 1px solid var(--local--border-color);
+		border-radius: var(--wp--custom--button--border--radius);
+	}
+
+	&.wp-block-search__button-inside {
+		.wp-block-search__inside-wrapper {
+			border: 1px solid var(--local--border-color) !important;
+			border-radius: var(--wp--custom--button--border--radius);
+		}
+
+		button[type="submit"] {
+			margin: 2px;
+		}
+	}
+
+	&.wp-block-search__button-outside {
+		input[type="search"] {
+			border: 1px solid var(--local--border-color) !important;
+			border-radius: var(--wp--custom--button--border--radius);
+		}
+
+		button[type="submit"] {
+			border: 1px solid var(--local--border-color) !important;
+		}
+	}
+
+	&.wp-block-search__icon-button button[type="submit"] {
+		padding: calc(var(--wp--preset--spacing--10) / 2) !important;
+	}
+
+	&.wp-block-search__text-button button[type="submit"] {
+		border: 1px solid var(--local--border-color) !important;
+		font-size: var(--wp--preset--font-size--extra-small);
+		padding: var(--wp--preset--spacing--10) !important;
+	}
+}


### PR DESCRIPTION
The secondary search style is needed for the documentation site as well as showcase, so this PR moves the code from showcase to the parent theme.

I made a few changes to the styles in converting the CSS to Sass, the biggest change was remove `!important` when it wasn't necessary, and setting the custom properties for the button colors so the interactive states still work.

Lastly, I added a local custom prop for the border color, since documentation uses a light grey border, this way it can be set like this, to apply to all the borders.

```css
.wp-block-search.is-style-secondary-search-control {
	--local--border-color: var(--wp--preset--color--light-grey-1);
}
```

### Screenshots

Style is available on any site using the parent theme

<img width="280" alt="Screenshot 2022-11-30 at 1 54 36 PM" src="https://user-images.githubusercontent.com/541093/204884252-90b4c1ba-b113-4207-ba0e-0b9ed6539b95.png">

The variations of the search block with Secondary style

<img width="844" alt="Screenshot 2022-11-30 at 1 51 12 PM" src="https://user-images.githubusercontent.com/541093/204883811-9c4b163c-2670-4412-857f-7256e24956e2.png">

In context on showcase

<img width="1215" alt="Screenshot 2022-11-30 at 1 41 27 PM" src="https://user-images.githubusercontent.com/541093/204883818-4c1baf8c-e1f3-4ca3-8b58-7482fe82bd3d.png">

### How to test the changes in this Pull Request:

1. Add a search block to a page or template, you should see the Secondary style option
2. Apply the style, the block should match the screenshots above (the editor view doesn't totally match, check frontend only)
3. Try with the showcase PR TBD, there should be no visual change on showcase.
