### PR TITLE
Navigation: Bold only the direct child of the current-menu-item li

### DIFF
--- a/source/wp-content/themes/wporg-parent-2021/sass/blocks/_navigation.scss
+++ b/source/wp-content/themes/wporg-parent-2021/sass/blocks/_navigation.scss
@@ -11,7 +11,7 @@
 		}
 	}
 
-	.current-menu-item {
+	.current-menu-item > a {
 		font-weight: 700;
 	}
 }


### PR DESCRIPTION
In https://github.com/WordPress/wporg-parent-2021/commit/40f4a3dba3e477502ca7fbe5a82f986828eb239d, the fix for https://github.com/WordPress/wporg-parent-2021/issues/55, the CSS added was a little overly broad. It applies to all nested links in the current menu item's `li`, which also includes submenus. This caused the dropdowns in the global nav to all be bold. This PR restricts that bold style to just the direct child link.

Fixes https://github.com/WordPress/wporg-mu-plugins/issues/306

### Screenshots

Before, the dropdown items are all bold. After, only the current item is bold, but the menu item in the subnav is still correctly highlighted.

| Before | After |
|--------|-------|
| ![Screen Shot 2022-12-09 at 17 13 37](https://user-images.githubusercontent.com/541093/206804365-0ec2e8bc-83b3-4877-afb5-11f3fa7ebea5.png) | ![Screen Shot 2022-12-09 at 17 13 27](https://user-images.githubusercontent.com/541093/206804361-6f36adc3-5091-477e-8e0c-3820673da5c0.png) |
