### PR TITLE
Use currentColor for the external link.

### DIFF
--- a/source/wp-content/themes/wporg-parent-2021/sass/base/_elements.scss
+++ b/source/wp-content/themes/wporg-parent-2021/sass/base/_elements.scss
@@ -30,23 +30,16 @@ mark.has-inline-color {
 
 // For links that navigate users to different site
 a.external-link::after,
-a.external-link-light::after,
-.external-link > a:not([href*="wordpress.org"])::after,
-.external-link-light > a:not([href*="wordpress.org"])::after {
+.external-link > a:not([href*="wordpress.org"])::after {
 	content: "";
 	display: inline-flex;
-	background-color: var(--wp--preset--color--charcoal-4);
+	background-color: currentcolor;
 	width: 1em;
 	height: 1em;
 	margin-left: 0.1em;
 	vertical-align: middle;
 	mask-image: url(../images/external-link-icon.svg);
 	mask-size: cover;
-}
-
-a.external-link-light::after,
-.external-link-light > a:not([href*="wordpress.org"])::after {
-	background-color: var(--wp--preset--color--light-grey-2);
 }
 
 // Inline code tags should use the monospace font.


### PR DESCRIPTION
We have a case where we need the [external link to be blueberry](https://github.com/WordPress/wporg-showcase-2022/pull/110#issuecomment-1354572161). Instead of adding new classes for all the colors we could make use of `currentcolor` and use the text color. I initially missed that in the first PR. I wasn't aware that it would work in this case.
 
## Considerations
I don't believe there are any uses of `external-link` in the wild that would need replacing so this should be straightforward.


### Screenshots
|  | IMG |
| --- | --- |
| Color | <img width="280" alt="Screen Shot 2022-12-19 at 10 37 42 AM" src="https://user-images.githubusercontent.com/1657336/208331572-13f966c7-9637-4bff-adc7-db7660b89b49.png"> |
| Light| <img width="74" alt="Screen Shot 2022-12-19 at 10 37 22 AM" src="https://user-images.githubusercontent.com/1657336/208331575-285d9e4c-1a71-4d98-8895-4ed74945ae56.png">|
| Dark | <img width="125" alt="Screen Shot 2022-12-19 at 10 39 59 AM" src="https://user-images.githubusercontent.com/1657336/208331753-787f1080-c150-4ac6-946e-455f4aa7eaff.png">|


### How to test the changes in this Pull Request:

1. Load this PR
2. Add the class `external-link` to any `<a>` tag.
3. Expect the icon to have the color of the `<a>` tag.
