### PR TITLE
Styles: Update caption styles on gallery, images

### DIFF
--- a/source/wp-content/themes/wporg-parent-2021/sass/base/_elements.scss
+++ b/source/wp-content/themes/wporg-parent-2021/sass/base/_elements.scss
@@ -52,20 +52,28 @@ figure[class*="wp-block-"],
 [class*="wp-block-"] {
 	figcaption,
 	.wp-element-caption {
-		text-align: right;
+		text-align: center;
 	}
 
 	&.wp-block-gallery.has-nested-images {
-		> figcaption,
-		> .wp-element-caption {
-			margin-top: 0;
-		}
-	}
-
-	&.alignfull {
-		> figcaption,
-		> .wp-element-caption {
-			padding-right: var(--wp--style--block-gap);
+		figure.wp-block-image {
+			display: block;
+	
+			&:not(#individual-image) a,
+			&:not(#individual-image) img {
+				height: auto;
+			}
+	
+			figcaption,
+			.wp-element-caption {
+				position: static;
+				margin: calc(var(--wp--style--block-gap) / 2) 0 0;
+				padding: 0;
+				background: transparent;
+				color: var(--wp--preset--color--charcoal-4);
+				font-size: var(--wp--custom--gallery--caption--font-size);
+				line-height: 1.6;
+			}
 		}
 	}
 }

--- a/source/wp-content/themes/wporg-parent-2021/theme.json
+++ b/source/wp-content/themes/wporg-parent-2021/theme.json
@@ -755,6 +755,9 @@
 				}
 			},
 			"caption": {
+				"color": {
+					"text": "var(--wp--preset--color--charcoal-4)"
+				},
 				"typography": {
 					"fontSize": "var(--wp--custom--gallery--caption--font-size)"
 				},


### PR DESCRIPTION
This updates the gallery caption styles to better match the regular image & other media captions. It also centers the caption for all media — originally the captions were defaulted to right alignment to match News ([example](https://wordpress.org/news/2022/10/people-of-wordpress-raghavendra-satish-peri/)), but this was changed to centered for the Documentation design. @javierarce can you confirm whether centered captions should be the default for all the redesigned sites?

Fixes https://github.com/WordPress/wporg-documentation-2022/issues/29

### Screenshots

| | Before | After |
|----|--------|-------|
| Single image | ![before-image-w-caption](https://user-images.githubusercontent.com/541093/211405740-b3910eac-ac85-4199-9e9a-10b96352eaa9.png) | ![after-image-w-caption](https://user-images.githubusercontent.com/541093/211405737-564ad447-8e76-47b7-aa03-0d19087347b9.png) |
| Gallery | ![before-gallery-w-captions](https://user-images.githubusercontent.com/541093/211405738-3ec2fe53-d52c-4eb5-9338-62d9033d0f4e.png) | ![after-gallery-w-captions](https://user-images.githubusercontent.com/541093/211405736-46229be8-75cc-484c-a3a2-9e3ae84b6011.png) |
