### PR TITLE
Add list block style for long items

### DIFF
--- a/source/wp-content/themes/wporg-parent-2021/inc/block-styles.php
+++ b/source/wp-content/themes/wporg-parent-2021/inc/block-styles.php
@@ -141,6 +141,15 @@ function setup_block_styles() {
 	);
 
 	register_block_style(
+		'core/list',
+		array(
+			'name'         => 'list-long-items',
+			'label'        => __( 'Long items', 'wporg' ),
+			'style_handle' => STYLE_HANDLE,
+		)
+	);
+
+	register_block_style(
 		'core/navigation',
 		array(
 			'name'         => 'dropdown-on-mobile',

--- a/source/wp-content/themes/wporg-parent-2021/sass/block-styles.scss
+++ b/source/wp-content/themes/wporg-parent-2021/sass/block-styles.scss
@@ -585,3 +585,7 @@
 		padding: var(--wp--preset--spacing--10) !important;
 	}
 }
+
+.is-style-list-long-items > li {
+	margin-bottom: var(--wp--preset--spacing--20);
+}


### PR DESCRIPTION
Adds a 'Long items' style to list blocks which spaces out the list items. Required for spacing of content in the redesigned About/Features page, see #71 for design.

Closes #71 

Props @ryelle 

### Screenshots

| Editor | Frontend |
|--------|-------|
| ![Screen Shot 2023-02-02 at 12 37 10 PM](https://user-images.githubusercontent.com/1017872/216192582-36144ee3-ce0a-4034-a654-433044e4941f.jpg) | ![localhost_8888_about-font-test_(Desktop)](https://user-images.githubusercontent.com/1017872/216192608-4f6e7481-cdc1-4d1f-bb68-a495be9a9364.png) |
