### PR TITLE
Try using a filter to merge child & parent theme.json settings

### DIFF
--- a/source/wp-content/themes/wporg-parent-2021/functions.php
+++ b/source/wp-content/themes/wporg-parent-2021/functions.php
@@ -17,6 +17,7 @@ add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\enqueue_assets' );
 add_filter( 'author_link', __NAMESPACE__ . '\use_wporg_profile_for_author_link', 10, 3 );
 add_filter( 'render_block_core/pattern', __NAMESPACE__ . '\prevent_arrow_emoji', 20 );
 add_filter( 'the_content', __NAMESPACE__ . '\prevent_arrow_emoji', 20 );
+add_filter( 'wp_theme_json_data_theme', __NAMESPACE__ . '\merge_parent_child_theme_json' );
 
 /**
  * Register theme support.
@@ -104,6 +105,114 @@ function use_wporg_profile_for_author_link( $link, $author_id, $author_nicename 
  */
 function prevent_arrow_emoji( $content ) {
 	return preg_replace( '/([←↑→↓↔↕↖↗↘↙])/u', '\1&#65038;', $content );
+}
+
+/**
+ * Merge the child theme's theme.json into the parent theme.json.
+ *
+ * Pull the parent theme's values for array settings out and merge them by slug
+ * with the values in the child theme. This prevents values in the child theme
+ * from blowing away the parent theme's settings.
+ *
+ * Additional settings are merged correctly, since they're objects (and merged
+ * by key).
+ *
+ * See https://github.com/WordPress/gutenberg/issues/40557.
+ *
+ * @param WP_Theme_JSON_Data $theme_json Parsed child theme.json.
+ *
+ * @return WP_Theme_JSON_Data The updated theme.json settings.
+ */
+function merge_parent_child_theme_json( $theme_json ) {
+	// Nothing to merge if this is not a child theme.
+	if ( get_template_directory() === get_stylesheet_directory() ) {
+		return $theme_json;
+	}
+
+	// Build a new theme.json object.
+	$new_data = array(
+		'version' => 2,
+	);
+
+	$child_theme = $theme_json->get_data();
+
+	if ( ! empty( $child_theme['settings'] ) ) {
+		$parent_theme_json_file = get_template_directory() . '/theme.json';
+		$parent_theme_json_data = wp_json_file_decode( $parent_theme_json_file, array( 'associative' => true ) );
+		$parent_theme           = new \WP_Theme_JSON_Gutenberg( $parent_theme_json_data );
+
+		// Get base theme.json settings.
+		$theme_settings = $parent_theme->get_settings();
+		$settings       = $child_theme['settings'];
+
+		// Define the array values here, so they can be updated if the theme.json schema changes.
+		$color_keys = [ 'duotone', 'gradient', 'palette' ];
+		$typog_keys = [ 'fontFamilies', 'fontSizes' ];
+		$space_keys = [ 'spacingSizes' ];
+
+		foreach ( $color_keys as $key ) {
+			if ( ! empty( $settings['color'][ $key ]['theme'] ) ) {
+				$settings['color'][ $key ]['theme'] = _merge_by_slug(
+					$theme_settings['color'][ $key ]['theme'],
+					$settings['color'][ $key ]['theme']
+				);
+
+			}
+		}
+
+		foreach ( $typog_keys as $key ) {
+			if ( ! empty( $settings['typography'][ $key ]['theme'] ) ) {
+				$settings['typography'][ $key ]['theme'] = _merge_by_slug(
+					$theme_settings['typography'][ $key ]['theme'],
+					$settings['typography'][ $key ]['theme']
+				);
+			}
+		}
+
+		foreach ( $space_keys as $key ) {
+			if ( ! empty( $settings['spacing'][ $key ]['theme'] ) ) {
+				$settings['spacing'][ $key ]['theme'] = _merge_by_slug(
+					$theme_settings['spacing'][ $key ]['theme'],
+					$settings['spacing'][ $key ]['theme']
+				);
+			}
+		}
+
+		$new_data['settings'] = $settings;
+	}
+
+	return $theme_json->update_with( $new_data );
+}
+
+/**
+ * Merge two (or more) arrays, de-duplicating by the `slug` key.
+ *
+ * If any values in later arrays have slugs matching earlier items, the earlier
+ * items are overwritten with the later value.
+ *
+ * @param array ...$arrays A list of arrays of associative arrays, each item
+ *                         must have a `slug` key.
+ *
+ * @return array The combined array, unique by `slug`. Empty if any item is
+ *               missing a slug.
+ */
+function _merge_by_slug( ...$arrays ) {
+	$combined = array_merge( ...$arrays );
+	$result   = [];
+
+	foreach ( $combined as $value ) {
+		if ( ! isset( $value['slug'] ) ) {
+			return [];
+		}
+
+		$found = array_search( $value['slug'], wp_list_pluck( $result, 'slug' ), true );
+		if ( false !== $found ) {
+			$result[ $found ] = $value;
+		} else {
+			$result[] = $value;
+		}
+	}
+	return $result;
 }
 
 /**

--- a/source/wp-content/themes/wporg-parent-2021/functions.php
+++ b/source/wp-content/themes/wporg-parent-2021/functions.php
@@ -142,8 +142,8 @@ function merge_parent_child_theme_json( $theme_json ) {
 		$parent_theme           = new \WP_Theme_JSON_Gutenberg( $parent_theme_json_data );
 
 		// Get base theme.json settings.
-		$theme_settings = $parent_theme->get_settings();
-		$settings       = $child_theme['settings'];
+		$parent_settings = $parent_theme->get_settings();
+		$child_settings  = $child_theme['settings'];
 
 		// Define the array values here, so they can be updated if the theme.json schema changes.
 		$color_keys = [ 'duotone', 'gradient', 'palette' ];
@@ -151,34 +151,34 @@ function merge_parent_child_theme_json( $theme_json ) {
 		$space_keys = [ 'spacingSizes' ];
 
 		foreach ( $color_keys as $key ) {
-			if ( ! empty( $settings['color'][ $key ]['theme'] ) ) {
-				$settings['color'][ $key ]['theme'] = _merge_by_slug(
-					$theme_settings['color'][ $key ]['theme'],
-					$settings['color'][ $key ]['theme']
+			if ( ! empty( $child_settings['color'][ $key ]['theme'] ) ) {
+				$child_settings['color'][ $key ]['theme'] = _merge_by_slug(
+					$parent_settings['color'][ $key ]['theme'],
+					$child_settings['color'][ $key ]['theme']
 				);
 
 			}
 		}
 
 		foreach ( $typog_keys as $key ) {
-			if ( ! empty( $settings['typography'][ $key ]['theme'] ) ) {
-				$settings['typography'][ $key ]['theme'] = _merge_by_slug(
-					$theme_settings['typography'][ $key ]['theme'],
-					$settings['typography'][ $key ]['theme']
+			if ( ! empty( $child_settings['typography'][ $key ]['theme'] ) ) {
+				$child_settings['typography'][ $key ]['theme'] = _merge_by_slug(
+					$parent_settings['typography'][ $key ]['theme'],
+					$child_settings['typography'][ $key ]['theme']
 				);
 			}
 		}
 
 		foreach ( $space_keys as $key ) {
-			if ( ! empty( $settings['spacing'][ $key ]['theme'] ) ) {
-				$settings['spacing'][ $key ]['theme'] = _merge_by_slug(
-					$theme_settings['spacing'][ $key ]['theme'],
-					$settings['spacing'][ $key ]['theme']
+			if ( ! empty( $child_settings['spacing'][ $key ]['theme'] ) ) {
+				$child_settings['spacing'][ $key ]['theme'] = _merge_by_slug(
+					$parent_settings['spacing'][ $key ]['theme'],
+					$child_settings['spacing'][ $key ]['theme']
 				);
 			}
 		}
 
-		$new_data['settings'] = $settings;
+		$new_data['settings'] = $child_settings;
 	}
 
 	return $theme_json->update_with( $new_data );


### PR DESCRIPTION
This updates the theme.json resolver to merge in parent theme settings for the array properties (color palette, font sizes, etc) before merging back into the parent theme.

Previously, defining an array property would totally overwrite the parent theme value. Now this hooks in `wp_theme_json_data_theme` to merge the list defined in the parent theme into the child theme's value, using a helper function `_merge_by_slug`. This only updates those properties that need merging, the core process of merging the child & parent theme.json happens [right after this filter returns](https://github.com/WordPress/gutenberg/blob/53fab106f062458f5da0efa2f031184b9ce0381f/lib/class-wp-theme-json-resolver-gutenberg.php#L260-L275).

If the child theme.json has values with the same slug as something in the parent theme.json, the child theme will overwrite that single value. Additional values will be added to the end of the parent's list.

### Screenshots

There should be no visible changes on the current themes.

I've pushed a [testing branch](https://github.com/WordPress/wporg-developer/tree/try/local-style-changes) to developer, which adds a new color, updates some font sizes, and heading font using the latest i3 design. If you apply both and spin up developer, you'll see that the headings are all IBM Plex Mono. I also added green paragraphs to show that the color is set correctly 🙂 

![](https://user-images.githubusercontent.com/541093/217377038-7be23079-6e57-4bb4-bd6c-231e838e6577.png)

In the editor, there are different font sizes for the headings (these overwrote the parent).

<img width="282" alt="fontsizes" src="https://user-images.githubusercontent.com/541093/217377065-a912103b-591c-49b1-a408-ca18685ea8ef.png">

And the color palette has an additional green at the end (this was added to the parent).

<img width="577" alt="colors" src="https://user-images.githubusercontent.com/541093/217377068-78c18f14-015f-4606-b5e2-cfc818de447e.png">

### How to test the changes in this Pull Request:

1. Spin up a child theme site.
2. Add some changes into one of the array value properties, `color.palette`, `typography.fontFamilies`, `spacing.spacingSizes`, etc.
3. Open the editor, you should see your updated settings.
4. Try editing other things in the child theme.json, it should still update correctly on the front end.
