### PR TITLE
Use theme.json to remove small font size from tables

### DIFF
--- a/source/wp-content/themes/wporg-parent-2021/sass/blocks/_table.scss
+++ b/source/wp-content/themes/wporg-parent-2021/sass/blocks/_table.scss
@@ -9,10 +9,6 @@
 }
 
 .wp-block-table {
-	> table {
-		font-size: var(--wp--preset--font-size--normal);
-	}
-
 	th {
 		text-align: left;
 		font-weight: 400;

--- a/source/wp-content/themes/wporg-parent-2021/theme.json
+++ b/source/wp-content/themes/wporg-parent-2021/theme.json
@@ -698,11 +698,6 @@
 					"fontSize": "clamp(20px, calc(100vw / 12), 120px)"
 				}
 			},
-			"core/table": {
-				"typography": {
-					"fontSize": "var(--wp--preset--font-size--extra-small)"
-				}
-			},
 			"core/quote": {
 				"border": {
 					"color": "var(--wp--preset--color--deep-blueberry)",


### PR DESCRIPTION
See #76 

I mistakenly [added a CSS override](https://github.com/WordPress/wporg-parent-2021/pull/77) to reduce the font size of the table contents, I should have removed the setting from theme.json. This PR corrects that.

Props @ryelle 

