### PR TITLE
Element styles: Add margin to h2 & h3

### DIFF
--- a/source/wp-content/themes/wporg-parent-2021/sass/base/_elements.scss
+++ b/source/wp-content/themes/wporg-parent-2021/sass/base/_elements.scss
@@ -125,6 +125,16 @@ input[type="checkbox"] + label {
 	line-height: 1em; // stylelint-disable-line declaration-property-unit-allowed-list
 }
 
+// Headings.
+// Add margin to default h2 & h3 (no font size changes).
+.wp-site-blocks h2:not([class*="-font-size"], [style*="font-size"]) {
+	margin-top: var(--wp--preset--spacing--40);
+}
+
+.wp-site-blocks h3:not([class*="-font-size"], [style*="font-size"]) {
+	margin-top: var(--wp--preset--spacing--30);
+}
+
 // Line heights for custom sizes.
 .has-extra-small-font-size {
 	line-height: var(--wp--custom--body--extra-small--typography--line-height);

--- a/source/wp-content/themes/wporg-parent-2021/theme.json
+++ b/source/wp-content/themes/wporg-parent-2021/theme.json
@@ -642,24 +642,6 @@
 					"fontSize": "var(--wp--preset--font-size--normal)"
 				}
 			},
-			"core/post-content": {
-				"elements": {
-					"h2": {
-						"spacing": {
-							"margin": {
-								"top": "var(--wp--preset--spacing--40)"
-							}
-						}
-					},
-					"h3": {
-						"spacing": {
-							"margin": {
-								"top": "var(--wp--preset--spacing--30)"
-							}
-						}
-					}
-				}
-			},
 			"core/post-date": {
 				"typography": {
 					"fontSize": "var(--wp--preset--font-size--small)"


### PR DESCRIPTION
This moves the heading margin from `theme.json`, where it only applied to real content (articles in docs), but not content from patterns (the page content on the main site). Now the margin is applied to all `h2`s and `h3`s without custom font sizes (if a font size is added and a margin is necessary, it can be added in the editor too).

See https://github.com/WordPress/wporg-main-2022/issues/246
This is an alternative to https://github.com/WordPress/wporg-main-2022/pull/251, assuming these values should cascade to all pages on the site. If the margins should only apply to the current pages, the in-content approach of 251 makes more sense, but since the same values are used on Documentation, I thought it should be provided by the parent theme.

### Screenshots

Ran `blink-diff` across screenshots. The first screenshot is `trunk`, the last is this PR, and the middle highlights differences. The only difference is the spacing on About - Philosophy & About - Requirements.

![result-home-1280](https://user-images.githubusercontent.com/541093/231232788-8b6beafd-99e0-406d-8603-a77960972363.png)
![result-download-1280](https://user-images.githubusercontent.com/541093/231232785-9ffab979-743c-4617-9b73-1893954972b4.png)
![result-dl-releases-1280](https://user-images.githubusercontent.com/541093/231232771-131428d6-82f2-4a45-a8ff-4692e8c332bb.png)

![result-about-1280](https://user-images.githubusercontent.com/541093/231232754-b0d292cd-4f6b-4b75-9e58-757143a60582.png)
![result-about-philosophy-1280](https://user-images.githubusercontent.com/541093/231232760-dbe49cde-022e-41c4-ad1b-dcb0f82e9a56.png)
![result-about-requirements-1280](https://user-images.githubusercontent.com/541093/231232768-5b15ad07-7912-4a3b-a753-134435ad26fd.png)

![result-docs-home-1280](https://user-images.githubusercontent.com/541093/231232779-69dcd933-7331-40f7-8f55-cd686a95d4c3.png)
![result-docs-topic-landing-1280](https://user-images.githubusercontent.com/541093/231232781-73453e75-12b1-4914-87b9-53d716ead0e9.png)
![result-docs-category-1280](https://user-images.githubusercontent.com/541093/231232777-737a5ddf-a8b0-4364-9c5d-f6b50f155f61.png)
![result-docs-article-1280](https://user-images.githubusercontent.com/541093/231232772-2a94fa27-1fb6-4d98-a116-2137c69294b0.png)

### How to test the changes in this Pull Request:

1. Pull down the branch and build the styles `yarn workspaces run build`
2. Spin up a child theme site (see [step 5 in docs setup](https://github.com/WordPress/wporg-documentation-2022#setup) or [main setup](https://github.com/WordPress/wporg-main-2022/#setup) for testing with a real child theme) or push to a sandbox.
3. Any pages with plain h2 & h3 should have spacing, for example articles on Documentation or pages in the About section
4. The spacing does not affect other existing pages (generally because they've got custom font sizes)
