### PR TITLE
Fix content breaking out of main container

### DIFF
--- a/source/wp-content/themes/wporg-parent-2021/sass/base/_layout.scss
+++ b/source/wp-content/themes/wporg-parent-2021/sass/base/_layout.scss
@@ -3,6 +3,7 @@
 	display: flex;
 	flex-direction: column;
 	min-height: calc(100vh - var(--wp-global-header-offset, 0px) - var(--local-header-height, 0px));
+	overflow-wrap: break-word;
 
 	> main,
 	> article {

--- a/source/wp-content/themes/wporg-parent-2021/sass/blocks/_index.scss
+++ b/source/wp-content/themes/wporg-parent-2021/sass/blocks/_index.scss
@@ -8,6 +8,7 @@
 @import "post-excerpt";
 @import "post-navigation-link";
 @import "post-title";
+@import "preformatted";
 @import "pullquote";
 @import "query-pagination";
 @import "quote";

--- a/source/wp-content/themes/wporg-parent-2021/sass/blocks/_preformatted.scss
+++ b/source/wp-content/themes/wporg-parent-2021/sass/blocks/_preformatted.scss
@@ -1,0 +1,5 @@
+.wp-block-preformatted {
+	white-space: pre;
+	overflow-x: scroll;
+	overflow-wrap: normal;
+}

--- a/source/wp-content/themes/wporg-parent-2021/sass/blocks/_search.scss
+++ b/source/wp-content/themes/wporg-parent-2021/sass/blocks/_search.scss
@@ -16,7 +16,6 @@
 	margin-top: var(--wp--custom--margin--baseline);
 
 	> label {
-		width: 100%;
 		margin-bottom: calc(var(--wp--custom--form--padding) / 2);
 		font-size: var(--wp--custom--form--typography--font-size);
 		color: var(--wp--custom--form--color--label);


### PR DESCRIPTION
Fixes https://github.com/WordPress/wporg-documentation-2022/issues/50 — Force a word break on content so that the text wraps rather than breaking out of the container.

This also removes the wrap from `pre` blocks, since they're usually code and the wrap distorts the indentation.

### Screenshots

Three examples from Docs, and one from About, to show this works across the child themes.

| | Before | After |
|---|---|---|
| [1. Preformatted](https://wordpress.org/documentation/article/tools-network-screen/)<br />Docs | ![t-preformatted](https://user-images.githubusercontent.com/541093/231297218-466f3de6-a07e-4316-8265-6c620a58b27c.png) | ![b-preformatted](https://user-images.githubusercontent.com/541093/231297213-64f54470-e1b8-4d8f-ab43-bd5f74312976.png) |
| [2. Code](https://wordpress.org/documentation/article/wordpress-glossary/)<br />Docs | ![t-list-code](https://user-images.githubusercontent.com/541093/231297216-c6afbdc9-015a-4786-916c-fe56b1a38bbe.png) | ![b-list-code](https://user-images.githubusercontent.com/541093/231297209-401e2a83-19b3-42cd-acb2-7f242f3d6658.png) |
| [3. Link](https://wordpress.org/about/privacy/)<br />About | ![t-list-link](https://user-images.githubusercontent.com/541093/231297217-cf291310-18d9-4e25-8f88-c888b910a3fe.png) | ![b-list-link](https://user-images.githubusercontent.com/541093/231297211-136d4ae0-b4ef-4df5-ac06-0ad43c7d7e66.png) |
| [4. Tables](https://wordpress.org/documentation/article/comparing-patterns-template-parts-and-reusable-blocks/)<br />No difference, already works | ![t-table](https://user-images.githubusercontent.com/541093/231297219-de222670-c29d-4502-a3bf-1d37e47cd6b4.png) | ![b-table](https://user-images.githubusercontent.com/541093/231297215-62d7408d-05b2-4662-942c-bfb6cde4890e.png) |

https://wordpress.org/documentation/article/twenty-twenty-changelog/ — For this one I edited the article itself to remove the `&nbsp;`s between the words, which along with the break-word rule correctly wraps on small screens.

https://wordpress.org/documentation/article/what-are-smilies/ — This was another page with slightly malformed content, the table block was missing the figure wrapper. Just by updating the page I fixed the table display and now it overflows with a scroll instead of breaking the container.

### How to test the changes in this Pull Request:

1. Apply this to a sandbox
2. View any of the linked pages on https://github.com/WordPress/wporg-documentation-2022/issues/50
3. The page should not have a horizontal scroll
4. Some elements on the page (preformatted blocks, tables) might have a horizontal scroll
5. Check other pages at larger sizes too for regressions
