### PR TITLE
Styles: Add underline to default link style.

### DIFF
--- a/source/wp-content/themes/wporg-parent-2021/sass/base/_elements.scss
+++ b/source/wp-content/themes/wporg-parent-2021/sass/base/_elements.scss
@@ -1,14 +1,13 @@
 // Links
 a {
 	cursor: pointer;
-	text-decoration: none;
 	text-decoration-thickness: 1px;
 	text-underline-offset: 0.15em;
 	font-weight: revert; // stylelint-disable-line font-weight-notation
 
 	&:hover,
 	&:focus {
-		text-decoration-line: underline;
+		text-decoration-line: none;
 	}
 }
 

--- a/source/wp-content/themes/wporg-parent-2021/theme.json
+++ b/source/wp-content/themes/wporg-parent-2021/theme.json
@@ -647,6 +647,20 @@
 					"fontSize": "var(--wp--preset--font-size--small)"
 				}
 			},
+			"core/post-navigation-link": {
+				"elements": {
+					"link": {
+						"typography": {
+							"textDecoration": "none"
+						},
+						":hover": {
+							"typography": {
+								"textDecoration": "underline"
+							}
+						}
+					}
+				}
+			},
 			"core/post-terms": {
 				"typography": {
 					"fontSize": "var(--wp--preset--font-size--small)"
@@ -678,6 +692,18 @@
 			"core/site-title": {
 				"typography": {
 					"fontSize": "clamp(20px, calc(100vw / 12), 120px)"
+				},
+				"elements": {
+					"link": {
+						"typography": {
+							"textDecoration": "none"
+						},
+						":hover": {
+							"typography": {
+								"textDecoration": "underline"
+							}
+						}
+					}
 				}
 			},
 			"core/quote": {


### PR DESCRIPTION
I noticed in https://github.com/WordPress/wporg-main-2022/issues/268#issuecomment-1586557246 that the design appears to have underlines on links by default, but our parent theme removes those. Links in post content are underlined, but in the main theme we don't use post content blocks. On Documentation, there's a rule to [add underlines](https://github.com/WordPress/wporg-documentation-2022/blob/8b48a2645a2b080222b2fea56e178ff68d13f84b/source/wp-content/themes/wporg-documentation-2022/src/style/style.scss#L11) to keep things consistent, but if this is merged we can probably remove that.

This only affects default link styles — buttons, links in navigation menus, and styled links (like the list pattern) are not affected.

### Screenshots

Note that the homepage before screenshot shows the banner link not-underlined, that's because I actually added a manual underline to it on production, which was removed for testing this PR.

| Before | After |
|--------|-------|
| ![before-home](https://github.com/WordPress/wporg-parent-2021/assets/541093/f0fa9228-234c-4b9f-bd40-a99bf00ff417) | ![after-home](https://github.com/WordPress/wporg-parent-2021/assets/541093/d67e6761-25ee-44af-9388-de61f415b67f) |
| ![before-download](https://github.com/WordPress/wporg-parent-2021/assets/541093/94e7db72-e829-499e-8e1f-837f1f2788eb) | ![after-download](https://github.com/WordPress/wporg-parent-2021/assets/541093/02530a33-7b10-479f-9b53-42b41c96f853) |
| ![before-about](https://github.com/WordPress/wporg-parent-2021/assets/541093/803bf042-db8a-4ba9-b831-8f6e6fca7627) | ![after-about](https://github.com/WordPress/wporg-parent-2021/assets/541093/844af23f-7b3a-47ba-99fe-61d59cce5bd2) |
| ![before-about-reqs](https://github.com/WordPress/wporg-parent-2021/assets/541093/64cfc562-1116-47e3-ac41-44233f453eb9) | ![after-about-reqs](https://github.com/WordPress/wporg-parent-2021/assets/541093/99036e18-0293-45c8-b908-5eff6da90fa4) |
| ![before-docs](https://github.com/WordPress/wporg-parent-2021/assets/541093/45642d2f-4d22-4f6e-9594-49201cae3709) | ![after-docs](https://github.com/WordPress/wporg-parent-2021/assets/541093/d74be756-088a-40be-9ba0-9a6919182c0d) |

### How to test the changes in this Pull Request:

1. Spin up any of the child theme sites (main, documentation, etc)
2. Check that default links have underlines, and that the underlines disappear on hover.
