### PR TITLE
Remove constrained width from separator with dots

### DIFF
--- a/source/wp-content/themes/wporg-parent-2021/sass/blocks/_separator.scss
+++ b/source/wp-content/themes/wporg-parent-2021/sass/blocks/_separator.scss
@@ -6,7 +6,7 @@
 		border-top-width: 0;
 	}
 
-	&:not(.is-style-wide) {
+	&:not(.is-style-wide):not(.is-style-dots) {
 		width: var(--wp--custom--separator--width);
 	}
 }


### PR DESCRIPTION
Fixes #89 

This PR updates the separator styles to opt the dots style out of the default width restriction, the same way we do for the wide style.

### Screenshots

| Before | After | Other styles |
|--------|-------|-|
| ![Screenshot 2023-07-21 at 11 40 17 AM](https://github.com/WordPress/wporg-parent-2021/assets/1017872/a08478c0-7a23-4ca2-93aa-7adde33aeb1d) | ![Screenshot 2023-07-21 at 11 54 15 AM](https://github.com/WordPress/wporg-parent-2021/assets/1017872/b547f3f7-1c6c-4de8-b916-ca1259827230) | ![Screenshot 2023-07-21 at 11 59 09 AM](https://github.com/WordPress/wporg-parent-2021/assets/1017872/73114ed4-b1ab-4557-b31f-96c92389b931) |

### How to test the changes in this Pull Request:

1. Checkout this branch in your sandbox and build the styles
2. Preview the draft page at https://wordpress.org/wp-admin/post.php?post=19658&action=edit
3. Regression test the other separator styles (Default, Wide Line)


