### PR TITLE
Add `has-display-block` utility class

### DIFF
--- a/source/wp-content/themes/wporg-parent-2021/sass/base/_utilities.scss
+++ b/source/wp-content/themes/wporg-parent-2021/sass/base/_utilities.scss
@@ -13,6 +13,11 @@
 	overflow: hidden;
 }
 
+// `display: block` cannot currently be saved in inline styles on elements in the html block
+.has-display-block {
+	display: block;
+}
+
 // This should only be used on template part containers to work around nested
 // sticky headers.
 // See https://github.com/WordPress/wporg-parent-2021/commit/49347b094f16835895c499a6181ca0e6fd853090


### PR DESCRIPTION
See #92

To fix [an accessibility issue in the About 6.3 page](https://github.com/WordPress/wporg-main-2022/issues/302), the video element in a custom html block needs inline style `display: block`. This style is being stripped on save though, so this utility class is being added to work around that.

See updated pattern which uses the class in https://github.com/WordPress/wporg-main-2022/pull/303
