### PR TITLE
Prevent screen readers from reading the arrow emoji in content

### DIFF
--- a/source/wp-content/themes/wporg-parent-2021/functions.php
+++ b/source/wp-content/themes/wporg-parent-2021/functions.php
@@ -15,6 +15,8 @@ require_once __DIR__ . '/inc/block-styles.php';
 add_action( 'after_setup_theme', __NAMESPACE__ . '\theme_support', 9 );
 add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\enqueue_assets' );
 add_filter( 'author_link', __NAMESPACE__ . '\use_wporg_profile_for_author_link', 10, 3 );
+add_filter( 'render_block_core/pattern', __NAMESPACE__ . '\add_aria_hidden_to_arrows', 19 );
+add_filter( 'the_content', __NAMESPACE__ . '\add_aria_hidden_to_arrows', 19 );
 add_filter( 'render_block_core/pattern', __NAMESPACE__ . '\prevent_arrow_emoji', 20 );
 add_filter( 'the_content', __NAMESPACE__ . '\prevent_arrow_emoji', 20 );
 add_filter( 'wp_theme_json_data_theme', __NAMESPACE__ . '\merge_parent_child_theme_json' );
@@ -92,6 +94,20 @@ function use_wporg_profile_for_author_link( $link, $author_id, $author_nicename 
 		'https://profiles.wordpress.org/%s/',
 		$author_nicename
 	);
+}
+
+/**
+ * Wrap the arrow emoji in an aria-hidden span tag, to prevent screen readers
+ * from trying to read them.
+ *
+ * This runs just before `prevent_arrow_emoji`, so that the variation-selector
+ * can be added inside the span.
+ *
+ * @param string $content Content of the current post.
+ * @return string The updated content.
+ */
+function add_aria_hidden_to_arrows( $content ) {
+	return preg_replace( '/([←↑→↓↔↕↖↗↘↙])/u', '<span aria-hidden="true">\1</span>', $content );
 }
 
 /**


### PR DESCRIPTION
See https://github.com/WordPress/wporg-main-2022/issues/311

> Please eliminate the "↗︎" icons on the links under the "Only the beginning" heading 2. You never know what screen readers will do when they come in contact with arrows. In all fairness, up arrows really don't make much sense here.

This PR will wrap any arrows in content (or patterns, which are content) in a `<span aria-hidden="true">` tag. There should be no visual change, but it should improve the screen reader experience. Adding this to the parent theme will cascade the effect down to all child themes, which share this links list with arrows pattern.

### Screenshots

Confirming no visual change.

| Before | After |
|--------|-------|
| ![trunk-home](https://github.com/WordPress/wporg-parent-2021/assets/541093/4c0e45b1-d994-40a4-adf7-f15c43cc8f6c) | ![branch-home](https://github.com/WordPress/wporg-parent-2021/assets/541093/5f68d85a-f4cb-4c79-b6cc-efbbe89ad009) |
| ![trunk-blocks](https://github.com/WordPress/wporg-parent-2021/assets/541093/cdd11634-6ce6-42f9-a35b-c7d7542ad5f7) | ![branch-blocks](https://github.com/WordPress/wporg-parent-2021/assets/541093/5af8f0d5-ca42-4e53-ab92-85039baf1ee0) |

### How to test the changes in this Pull Request:

1. Apply the branch, and start an environment using a child theme, for example the main site
2. View a page with arrows (home, blocks) or create a new page with arrow emoji — use any of `←↑→↓↔↕↖↗↘↙`
3. When viewed on the frontend, the arrows should be wrapped in span

