### PR TITLE
Styles: Update the button block styles

### DIFF
--- a/source/wp-content/themes/wporg-parent-2021/sass/blocks/_button-mixins.scss
+++ b/source/wp-content/themes/wporg-parent-2021/sass/blocks/_button-mixins.scss
@@ -91,9 +91,7 @@
 		padding-left: calc(var(--wp--custom--button--spacing--padding--left) + var(--wp--custom--button--border--width));
 		padding-right: calc(var(--wp--custom--button--spacing--padding--right) + var(--wp--custom--button--border--width));
 		border-width: 0;
-
-		background-color: var(--wp--custom--button--outline--color--background);
-		color: var(--wp--custom--button--outline--color--text);
+		background-color: var(--wp--custom--button--outline--focus--color--background);
 		outline-color: var(--wp--custom--button--outline--focus--border--color);
 	}
 

--- a/source/wp-content/themes/wporg-parent-2021/sass/blocks/_button-mixins.scss
+++ b/source/wp-content/themes/wporg-parent-2021/sass/blocks/_button-mixins.scss
@@ -28,7 +28,7 @@
 
 	&:focus {
 		background-color: var(--wp--custom--button--color--background);
-		box-shadow: inset 0 0 0 3px #fff;
+		box-shadow: inset 0 0 0 3px var(--wp--preset--color--white);
 		outline: 1.5px solid var(--wp--custom--button--focus--border--color);
 		outline-offset: -1.5px;
 	}

--- a/source/wp-content/themes/wporg-parent-2021/sass/blocks/_button-mixins.scss
+++ b/source/wp-content/themes/wporg-parent-2021/sass/blocks/_button-mixins.scss
@@ -27,11 +27,18 @@
 	}
 
 	&:focus {
-		outline: 1px dashed var(--wp--custom--button--hover--color--background);
-		outline-offset: 1px;
+		background-color: var(--wp--custom--button--color--background);
+		box-shadow: inset 0 0 0 3px #fff;
+		outline: 1.5px solid var(--wp--custom--button--focus--border--color);
+		outline-offset: -1.5px;
 	}
 
 	&:active {
+		padding-top: var(--wp--custom--button--spacing--padding--top);
+		padding-bottom: var(--wp--custom--button--spacing--padding--bottom);
+		padding-left: var(--wp--custom--button--spacing--padding--left);
+		padding-right: var(--wp--custom--button--spacing--padding--right);
+		border: var(--wp--custom--button--border--width) solid currentColor;
 		color: var(--wp--custom--button--active--color--text);
 		background-color: var(--wp--custom--button--active--color--background);
 
@@ -61,7 +68,7 @@
 
 @mixin button-outline-styles {
 	background-color: var(--wp--custom--button--outline--color--background);
-	border: 1px solid var(--wp--custom--button--outline--border--color);
+	border: var(--wp--custom--button--border--width) solid var(--wp--custom--button--outline--border--color);
 	color: var(--wp--custom--button--outline--color--text);
 
 	// Padding does not account for border width.
@@ -78,8 +85,16 @@
 	}
 
 	&:focus {
-		outline: 1px dashed var(--wp--custom--button--outline--hover--color--background);
-		outline-offset: 1px;
+		// Need to update the padding since the border was removed.
+		padding-top: calc(var(--wp--custom--button--spacing--padding--top) + var(--wp--custom--button--border--width));
+		padding-bottom: calc(var(--wp--custom--button--spacing--padding--bottom) + var(--wp--custom--button--border--width));
+		padding-left: calc(var(--wp--custom--button--spacing--padding--left) + var(--wp--custom--button--border--width));
+		padding-right: calc(var(--wp--custom--button--spacing--padding--right) + var(--wp--custom--button--border--width));
+		border-width: 0;
+
+		background-color: var(--wp--custom--button--outline--color--background);
+		color: var(--wp--custom--button--outline--color--text);
+		outline-color: var(--wp--custom--button--outline--focus--border--color);
 	}
 
 	&:active {

--- a/source/wp-content/themes/wporg-parent-2021/sass/blocks/_button.scss
+++ b/source/wp-content/themes/wporg-parent-2021/sass/blocks/_button.scss
@@ -31,7 +31,12 @@
 		--wp--custom--button--active--color--text: var(--wp--preset--color--white);
 		--wp--custom--button--active--color--background: transparent;
 		--wp--custom--button--active--border--color: var(--wp--preset--color--blueberry-2);
-		--wp--custom--button--focus--border--color: var(--wp--preset--color--blueberry-1);
+		--wp--custom--button--focus--border--color: var(--wp--preset--color--blueberry-2);
+
+		.wp-block-button__link:focus {
+			box-shadow: inset 0 0 0 3px var(--wp--custom--button--focus--border--color);
+			outline-color: #fff;
+		}
 	}
 
 	&.is-style-outline-on-dark {
@@ -46,7 +51,10 @@
 		--wp--custom--button--outline--active--border--color: var(--wp--preset--color--white);
 
 		.wp-block-button__link:focus {
-			outline-color: var(--wp--custom--button--outline--hover--color--text);
+			background-color: var(--wp--custom--button--outline--color--background);
+			color: var(--wp--custom--button--outline--color--text);
+			outline-color: #fff;
+			box-shadow: inset 0 0 0 3px var(--wp--custom--button--outline--hover--border--color);
 		}
 	}
 }

--- a/source/wp-content/themes/wporg-parent-2021/sass/blocks/_button.scss
+++ b/source/wp-content/themes/wporg-parent-2021/sass/blocks/_button.scss
@@ -53,7 +53,7 @@
 		.wp-block-button__link:focus {
 			background-color: var(--wp--custom--button--outline--color--background);
 			color: var(--wp--custom--button--outline--color--text);
-			outline-color: #fff;
+			outline-color: var(--wp--preset--color--white);
 			box-shadow: inset 0 0 0 3px var(--wp--custom--button--outline--hover--border--color);
 		}
 	}

--- a/source/wp-content/themes/wporg-parent-2021/sass/blocks/_button.scss
+++ b/source/wp-content/themes/wporg-parent-2021/sass/blocks/_button.scss
@@ -31,7 +31,7 @@
 		--wp--custom--button--active--color--text: var(--wp--preset--color--white);
 		--wp--custom--button--active--color--background: transparent;
 		--wp--custom--button--active--border--color: var(--wp--preset--color--blueberry-2);
-		--wp--custom--button--focus--border--color: var(--wp--preset--color--blueberry-2);
+		--wp--custom--button--focus--border--color: var(--wp--preset--color--blueberry-1);
 
 		.wp-block-button__link:focus {
 			box-shadow: inset 0 0 0 3px var(--wp--custom--button--focus--border--color);

--- a/source/wp-content/themes/wporg-parent-2021/sass/blocks/_button.scss
+++ b/source/wp-content/themes/wporg-parent-2021/sass/blocks/_button.scss
@@ -25,7 +25,7 @@
 		--wp--custom--button--color--text: var(--wp--preset--color--charcoal-1);
 		--wp--custom--button--color--background: var(--wp--preset--color--white);
 		--wp--custom--button--hover--color--text: var(--wp--preset--color--charcoal-1);
-		--wp--custom--button--hover--color--background: var(--wp--preset--color--white);
+		--wp--custom--button--hover--color--background: var(--wp--preset--color--blueberry-2);
 		--wp--custom--button--active--color--text: var(--wp--preset--color--white);
 		--wp--custom--button--active--color--background: transparent;
 	}
@@ -33,12 +33,12 @@
 	&.is-style-outline-on-dark {
 		--wp--custom--button--outline--color--text: var(--wp--preset--color--white);
 
-		--wp--custom--button--outline--hover--color--text: var(--wp--preset--color--white);
+		--wp--custom--button--outline--hover--color--text: var(--wp--preset--color--blueberry-2);
 		--wp--custom--button--outline--hover--color--background: transparent;
-		--wp--custom--button--outline--hover--border--color: var(--wp--preset--color--white);
+		--wp--custom--button--outline--hover--border--color: var(--wp--preset--color--blueberry-2);
 
-		--wp--custom--button--outline--active--color--text: var(--wp--preset--color--white);
-		--wp--custom--button--outline--active--color--background: transparent;
+		--wp--custom--button--outline--active--color--text: var(--wp--preset--color--charcoal-1);
+		--wp--custom--button--outline--active--color--background: var(--wp--preset--color--white);
 		--wp--custom--button--outline--active--border--color: var(--wp--preset--color--white);
 
 		.wp-block-button__link:focus {

--- a/source/wp-content/themes/wporg-parent-2021/sass/blocks/_button.scss
+++ b/source/wp-content/themes/wporg-parent-2021/sass/blocks/_button.scss
@@ -14,6 +14,8 @@
 
 	&.is-style-outline,
 	&.is-style-outline-on-dark {
+		color: var(--wp--custom--button--outline--color--text);
+
 		.wp-block-button__link {
 
 			@include button-color-styles;
@@ -28,6 +30,8 @@
 		--wp--custom--button--hover--color--background: var(--wp--preset--color--blueberry-2);
 		--wp--custom--button--active--color--text: var(--wp--preset--color--white);
 		--wp--custom--button--active--color--background: transparent;
+		--wp--custom--button--active--border--color: var(--wp--preset--color--blueberry-2);
+		--wp--custom--button--focus--border--color: var(--wp--preset--color--blueberry-1);
 	}
 
 	&.is-style-outline-on-dark {

--- a/source/wp-content/themes/wporg-parent-2021/theme.json
+++ b/source/wp-content/themes/wporg-parent-2021/theme.json
@@ -184,6 +184,9 @@
 					"focus": {
 						"border": {
 							"color": "var(--wp--preset--color--blueberry-1)"
+						},
+						"color": {
+							"background": "var(--wp--preset--color--blueberry-1)"
 						}
 					},
 					"active": {

--- a/source/wp-content/themes/wporg-parent-2021/theme.json
+++ b/source/wp-content/themes/wporg-parent-2021/theme.json
@@ -150,7 +150,15 @@
 						"text": "var(--wp--preset--color--white)"
 					}
 				},
+				"focus": {
+					"border": {
+						"color": "var(--wp--preset--color--blueberry-1)"
+					}
+				},
 				"active": {
+					"border": {
+						"color": "var(--wp--preset--color--blueberry-1)"
+					},
 					"color": {
 						"background": "var(--wp--preset--color--charcoal-1)",
 						"text": "var(--wp--preset--color--white)"
@@ -169,8 +177,13 @@
 							"color": "var(--wp--preset--color--blueberry-1)"
 						},
 						"color": {
-							"background": "var(--wp--preset--color--blueberry-1)",
+							"background": "var(--wp--preset--color--deep-blueberry)",
 							"text": "var(--wp--preset--color--white)"
+						}
+					},
+					"focus": {
+						"border": {
+							"color": "var(--wp--preset--color--blueberry-1)"
 						}
 					},
 					"active": {


### PR DESCRIPTION
Fixes #96 — Update the active, hover, and focus states for "on dark" buttons. This ensures the buttons have visible interactive states.

### Screenshots

<img width="1212" alt="buttons" src="https://github.com/WordPress/wporg-parent-2021/assets/541093/0202ae86-73e3-416a-9caa-2e82970a8df5">

### How to test the changes in this Pull Request:

1. Try adding some buttons
2. The various button states should match the design
