### PR TITLE
404: Pass correct `get_site_url` param to avoid infinite loop

### DIFF
--- a/source/wp-content/themes/wporg-parent-2021/patterns/404-page-subtitle.php
+++ b/source/wp-content/themes/wporg-parent-2021/patterns/404-page-subtitle.php
@@ -13,7 +13,7 @@
 	printf(
 		/* translators: %s is the site URL. */
 		wp_kses_post( __( 'Go to <a href="%s">the homepage</a> or try searching using the field below.', 'wporg' ) ),
-		esc_url( get_site_url( '/' ) )
+		esc_url( get_site_url( null, '/' ) )
 	);
 	?>
 </p>


### PR DESCRIPTION
The first param to `get_site_url()` should be a site ID, or `null` for the current site. Passing a string can cause a `switch_to_blog( 0 )` in some circumstances. That breaks SQL queries because the table doesn't exist. The first broken query results in a `wp_die()`, but that leads to more queries which in turn call `wp_die()`.

Passing `null` fixes the error while preserving the original intent from https://github.com/WordPress/wporg-parent-2021/pull/54#discussion_r1025741781.

I ran into this while trying to activate the parent theme on `events.wordpress.org` for https://github.com/WordPress/wordcamp.org/issues/1007