### PR TITLE
Styles: Update external link icon

### DIFF
--- a/source/wp-content/themes/wporg-parent-2021/images/external-link-icon.svg
+++ b/source/wp-content/themes/wporg-parent-2021/images/external-link-icon.svg
@@ -1,3 +1,3 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="48" height="48" aria-hidden="true" focusable="false">
-	<path d="M18.2 17c0 .7-.6 1.2-1.2 1.2H7c-.7 0-1.2-.6-1.2-1.2V7c0-.7.6-1.2 1.2-1.2h3.2V4.2H7C5.5 4.2 4.2 5.5 4.2 7v10c0 1.5 1.2 2.8 2.8 2.8h10c1.5 0 2.8-1.2 2.8-2.8v-3.6h-1.5V17zM14.9 3v1.5h3.7l-6.4 6.4 1.1 1.1 6.4-6.4v3.7h1.5V3h-6.3z"></path>
+<svg xmlns="http://www.w3.org/2000/svg" width="9" height="10" fill="none" viewBox="0 0 9 10" aria-hidden="true" focusable="false">
+  <path fill="#fff" d="M1.057 9.08.17 8.193l6.591-6.602h-5.09L1.68.364h7.194v7.204H7.636l.012-5.09L1.057 9.08Z"/>
 </svg>

--- a/source/wp-content/themes/wporg-parent-2021/sass/base/_elements.scss
+++ b/source/wp-content/themes/wporg-parent-2021/sass/base/_elements.scss
@@ -32,11 +32,11 @@ a.external-link::after,
 .external-link > a:not([href*="wordpress.org"])::after {
 	content: "";
 	display: inline-flex;
-	background-color: currentcolor;
-	width: 1em;
-	height: 1em;
-	margin-left: 0.1em;
-	vertical-align: middle;
+	background-color: currentColor;
+	width: 0.65em;
+	height: 0.65em;
+	margin-left: 0.25em;
+	vertical-align: baseline;
 	mask-image: url(../images/external-link-icon.svg);
 	mask-size: cover;
 }
@@ -57,12 +57,12 @@ figure[class*="wp-block-"],
 	&.wp-block-gallery.has-nested-images {
 		figure.wp-block-image {
 			display: block;
-	
+
 			&:not(#individual-image) a,
 			&:not(#individual-image) img {
 				height: auto;
 			}
-	
+
 			figcaption,
 			.wp-element-caption {
 				position: static;


### PR DESCRIPTION
The "external link" icon should be the up-right arrow [↗︎]. It is already used this way in the global header menu. This icon is also used on the site as a decorative element, in those spaces it's used inline as a real character. This does not change anything there.

When the `external-link` class is used on a link element or container (eg, paragraph), it will add the icon as a background, so that it is not underlined (and to prevent screen readers from reading it, see #94).

Fixes #64 — We've standardized on the single arrow, for both decorative and external links.

### Screenshots

| Before | After |
|--------|-------|
| <img width="295" alt="Screenshot 2023-08-30 at 4 10 40 PM" src="https://github.com/WordPress/wporg-parent-2021/assets/541093/9d8c0e31-cd0e-4a7c-8aa5-dfd364cba109">  | <img width="341" alt="Screenshot 2023-08-30 at 4 10 05 PM" src="https://github.com/WordPress/wporg-parent-2021/assets/541093/ddf16685-5172-4e68-a600-b5f28d7fbea3"> |

### How to test the changes in this Pull Request:

Try using this branch with the showcase site:

1. View a single site page
2. Below the title, the URL should have the new arrow icon

Or without a separate site:

1. Create a new post/page, add a paragraph
2. Add the `external-link` class to the paragraph under Advanced
3. Add a link in the paragraph content, not pointing to wordpress.org.
4. View on the front end
5. It should have the new arrow icon
