### PR TITLE
Add colors white opacity 15 and black opacity 15 to palette

### DIFF
--- a/source/wp-content/themes/wporg-parent-2021/theme.json
+++ b/source/wp-content/themes/wporg-parent-2021/theme.json
@@ -53,6 +53,11 @@
 					"name": "White"
 				},
 				{
+					"slug": "opacities-white-10",
+					"color": "rgba(255, 255, 255, 0.1)",
+					"name": "White 10%"
+				},
+				{
 					"slug": "dark-blueberry",
 					"color": "#1d35b4",
 					"name": "Dark Blueberry"

--- a/source/wp-content/themes/wporg-parent-2021/theme.json
+++ b/source/wp-content/themes/wporg-parent-2021/theme.json
@@ -53,9 +53,14 @@
 					"name": "White"
 				},
 				{
-					"slug": "opacities-white-10",
-					"color": "rgba(255, 255, 255, 0.1)",
-					"name": "White 10%"
+					"slug": "white-opacity-15",
+					"color": "#ffffff26",
+					"name": "White 15%"
+				},
+				{
+					"slug": "black-opacity-15",
+					"color": "#00000026",
+					"name": "Black 15%"
 				},
 				{
 					"slug": "dark-blueberry",


### PR DESCRIPTION
Closes #102 

Used in https://github.com/WordPress/wporg-developer/pull/271 and https://github.com/WordPress/wporg-documentation-2022/pull/67

### Screenshots

<img src="https://github.com/WordPress/wporg-parent-2021/assets/1017872/434d3e83-ae9c-4181-bc1b-351b6ad1d9ee" width="400">

### How to test the changes in this Pull Request:

1. Find the color in the block settings
2. Apply it and check that works
