### PR TITLE
Templates: Add comments to single post template

### DIFF
--- a/source/wp-content/themes/wporg-parent-2021/sass/blocks/_comments.scss
+++ b/source/wp-content/themes/wporg-parent-2021/sass/blocks/_comments.scss
@@ -1,0 +1,5 @@
+.wp-block-comment-template {
+	ol {
+		border-left: 1px solid var(--wp--preset--color--light-grey-1);
+	}
+}

--- a/source/wp-content/themes/wporg-parent-2021/sass/blocks/_index.scss
+++ b/source/wp-content/themes/wporg-parent-2021/sass/blocks/_index.scss
@@ -1,6 +1,7 @@
 // Override the default styles that a block has from Core, it's plugin, etc.
 @import "button";
 @import "columns";
+@import "comments";
 @import "file";
 @import "list";
 @import "navigation";

--- a/source/wp-content/themes/wporg-parent-2021/templates/single.html
+++ b/source/wp-content/themes/wporg-parent-2021/templates/single.html
@@ -10,11 +10,11 @@
 	</section>
 	<!-- /wp:group -->
 
-	<!-- wp:group {"align":"full","style":{"spacing":{"margin":{"top":"var:preset|spacing|60"}}}} -->
-	<div class="wp-block-group alignfull is-style-two-column-display" style="margin-top:var(--wp--preset--spacing--60)">
-		<!-- wp:comments -->
-		<div class="wp-block-comments">
-			<!-- wp:comments-title /-->
+	<!-- wp:group {"align":"full","style":{"spacing":{"margin":{"top":"0"}}}} -->
+	<div class="wp-block-group alignfull is-style-two-column-display" style="margin-top:0">
+		<!-- wp:comments {"style":{"spacing":{"margin":{"top":"var:preset|spacing|60"}}}} -->
+		<div class="wp-block-comments" style="margin-top:var(--wp--preset--spacing--60)">
+			<!-- wp:comments-title {"style":{"spacing":{"margin":{"top":"0"}}}} /-->
 
 			<!-- wp:comment-template -->
 				<!-- wp:group {"style":{"spacing":{"margin":{"bottom":"var:preset|spacing|30"}}},"layout":{"type":"default"}} -->

--- a/source/wp-content/themes/wporg-parent-2021/templates/single.html
+++ b/source/wp-content/themes/wporg-parent-2021/templates/single.html
@@ -9,6 +9,52 @@
 		<!-- wp:post-content {"className":"is-style-two-column-display","layout":{"inherit":true}} /-->
 	</section>
 	<!-- /wp:group -->
+
+	<!-- wp:group {"align":"full","style":{"spacing":{"margin":{"top":"var:preset|spacing|60"}}}} -->
+	<div class="wp-block-group alignfull is-style-two-column-display" style="margin-top:var(--wp--preset--spacing--60)">
+		<!-- wp:comments -->
+		<div class="wp-block-comments">
+			<!-- wp:comments-title /-->
+
+			<!-- wp:comment-template -->
+				<!-- wp:group {"style":{"spacing":{"margin":{"bottom":"var:preset|spacing|30"}}},"layout":{"type":"default"}} -->
+				<div class="wp-block-group" style="margin-bottom:var(--wp--preset--spacing--30)">
+					<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|30"}},"layout":{"type":"flex","flexWrap":"nowrap"}} -->
+					<div class="wp-block-group">
+						<!-- wp:avatar {"size":40,"style":{"border":{"radius":"20px"}}} /-->
+
+						<!-- wp:comment-author-name /-->
+
+						<!-- wp:comment-date /-->
+					</div>
+					<!-- /wp:group -->
+
+					<!-- wp:comment-content /-->
+			
+					<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|30","margin":{"bottom":"var:preset|spacing|20"}}},"layout":{"type":"flex","flexWrap":"nowrap"}} -->
+					<div class="wp-block-group" style="margin-bottom:var(--wp--preset--spacing--20)">
+						<!-- wp:comment-reply-link {"fontSize":"small"} /-->
+
+						<!-- wp:comment-edit-link {"fontSize":"small"} /-->
+					</div>
+					<!-- /wp:group -->
+				</div>
+				<!-- /wp:group -->
+			<!-- /wp:comment-template -->
+			
+			<!-- wp:comments-pagination {"layout":{"type":"flex","justifyContent":"space-between"}} -->
+				<!-- wp:comments-pagination-previous /-->
+				
+				<!-- wp:comments-pagination-numbers /-->
+				
+				<!-- wp:comments-pagination-next /-->
+			<!-- /wp:comments-pagination -->
+			
+			<!-- wp:post-comments-form /-->
+		</div>
+		<!-- /wp:comments -->
+	</div>
+	<!-- /wp:group -->
 </article>
 <!-- /wp:group -->
 

--- a/source/wp-content/themes/wporg-parent-2021/theme.json
+++ b/source/wp-content/themes/wporg-parent-2021/theme.json
@@ -666,6 +666,43 @@
 					"fontFamily": "var(--wp--preset--font-family--monospace)"
 				}
 			},
+			"core/comment-author-name": {
+				"typography": {
+					"fontWeight": "600"
+				},
+				"elements": {
+					"link": {
+						"typography": {
+							"textDecoration": "none"
+						},
+						":hover": {
+							"typography": {
+								"textDecoration": "underline"
+							}
+						}
+					}
+				}
+			},
+			"core/comment-date": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--small)"
+				},
+				"elements": {
+					"link": {
+						"color": {
+							"text": "var(--wp--preset--color--charcoal-4)"
+						},
+						"typography": {
+							"textDecoration": "none"
+						},
+						":hover": {
+							"typography": {
+								"textDecoration": "underline"
+							}
+						}
+					}
+				}
+			},
 			"core/navigation": {
 				"typography": {
 					"fontSize": "var(--wp--preset--font-size--normal)"


### PR DESCRIPTION
The current templates do not show any comments, but the Rosetta blogs need to support commenting. This adds a simple comment layout to the end of single post views.

Fixes https://github.com/WordPress/wporg-main-2022/issues/305

This should not affect the other sites that are already using the parent theme — the developer blog has a custom template, while documentation, developer, & showcase override the `single.html` template. 

@iandunn FYI for events.wordpress.org, but I don't think you have any views that would use `single.html` anyway.

### Screenshots

@WordPress/meta-design I referenced the ".org website hub" figma for comment reference, but didn't find anything so I just tried to keep it simple.

| | Screenshot |
|---|---|
| Single comment, replies open | ![](https://github.com/WordPress/wporg-parent-2021/assets/541093/d4c4b119-cdfd-4ed9-bd11-bdeb63be5ef0) |
| Multiple comments, replies closed (no form) | ![](https://github.com/WordPress/wporg-parent-2021/assets/541093/2757b3e5-3149-4a11-9703-808aa1bf7902) |
| No comments yet, with comment form | ![Screen Shot 2023-09-07 at 16 59 14](https://github.com/WordPress/wporg-parent-2021/assets/541093/b3bd472f-aac8-4652-a4af-0946b9e3b11f) |
| Threaded comments (rosetta sites don't support this currently) | <img width="739" alt="Screenshot 2023-09-07 at 5 30 03 PM" src="https://github.com/WordPress/wporg-parent-2021/assets/541093/6bc927ff-af64-4f9f-883e-09a820d1e030"> |

### How to test the changes in this Pull Request:

Try loading this PR on a sandbox and viewing the URL in the original issue.

To test locally…

1. Create & view a post with comments open
2. The reply form should appear
3. Add a comment
4. It should be loaded on the page
5. Add a few comments
6. They should show up as expected
7. View a post with comments disabled
8. There should be no reply form
9. Any previously entered comments will appear
