### PR TITLE
Update/spacing variables

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -158,20 +158,20 @@ Example of the generated property: `--wp--preset--font-size--extra-small`
 
 ### Spacing
 
-The responsive/scaling size values are still being updated, but for now they are as follows.
+The responsive/scaling size values are still being updated, but for now they are as follows. The "Min"/"Max" columns refer to where the scaling stops at each end of the scale. For example, at 590px, `--wp--preset--spacing--40` is 30px; while at 1320px, `--wp--preset--spacing--80` is 120px.
 
-| Name         | Slug         | Value                                   |
-|--------------|--------------|-----------------------------------------|
-| 3X-Small     | `10`         |  10px                                   |
-| 2X-Small     | `20`         |  20px                                   |
-| X-Small      | `30`         |  30px                                   |
-| Small        | `40`         |  40px                                   |
-| Medium       | `50`         | clamp( 40px, calc( 100vw / 16 ), 60px ) |
-| Large        | `60`         | clamp( 20px, calc( 100vw / 18 ), 80px ) |
-| X-Large      | `70`         | 100px                                   |
-| 2X-Large     | `80`         | clamp( 80px, calc( 100vw / 7 ), 120px ) |
-| 3X-Large     | `90`         | clamp( 80px, calc( 100vw / 7 ), 160px ) |
-| Edge Spacing | `edge-space` | 80px; <890px = 20px                     |
+| Name         | Slug         | Value                                   | Min | Max  |
+|--------------|--------------|-----------------------------------------|-----|------|
+| 3X-Small     | `10`         |  10px                                   |     |      |
+| 2X-Small     | `20`         |  20px                                   |     |      |
+| X-Small      | `30`         |  30px                                   |     |      |
+| Small        | `40`         | clamp(30px, 5vw, 50px)                  | 600 | 1000 |
+| Medium       | `50`         | clamp(40px, calc(5vw + 10px), 60px)     | 600 | 1000 |
+| Large        | `60`         | clamp(20px, calc(10vw - 40px), 80px)    | 600 | 1000 |
+| X-Large      | `70`         | 100px                                   |     |      |
+| 2X-Large     | `80`         | clamp(80px, calc(6.67vw + 40px), 120px) | 600 | 1200 |
+| 3X-Large     | `90`         | clamp(80px, 13.33vw, 160px)             | 600 | 1200 |
+| Edge Spacing | `edge-space` |  80px; <890px = 20px                    |     |      |
 
 ## History
 

--- a/source/wp-content/themes/wporg-parent-2021/theme.json
+++ b/source/wp-content/themes/wporg-parent-2021/theme.json
@@ -518,17 +518,17 @@
 				},
 				{
 					"name": "3X-Small",
-					"slug": 10,
+					"slug": "10",
 					"size": "10px"
 				},
 				{
 					"name": "2X-Small",
-					"slug": 20,
+					"slug": "20",
 					"size": "20px"
 				},
 				{
 					"name": "X-Small",
-					"slug": 30,
+					"slug": "30",
 					"size": "30px"
 				},
 				{
@@ -538,8 +538,8 @@
 				},
 				{
 					"name": "Medium",
-					"slug": 50,
-					"size": "clamp( 40px, calc( 100vw / 16 ), 60px )"
+					"slug": "50",
+					"size": "clamp(40px, calc(100vw / 16), 60px)"
 				},
 				{
 					"name": "Large",
@@ -548,18 +548,18 @@
 				},
 				{
 					"name": "X-Large",
-					"slug": 70,
+					"slug": "70",
 					"size": "100px"
 				},
 				{
 					"name": "2X-Large",
-					"slug": 80,
-					"size": "clamp( 80px, calc( 100vw / 7 ), 120px )"
+					"slug": "80",
+					"size": "clamp(80px, calc(100vw / 7), 120px)"
 				},
 				{
 					"name": "3X-Large",
-					"slug": 90,
-					"size": "clamp( 80px, calc( 100vw / 7 ), 160px )"
+					"slug": "90",
+					"size": "clamp(80px, calc(100vw / 7), 160px)"
 				}
 			]
 		},
@@ -766,7 +766,7 @@
 				"typography": {
 					"fontFamily": "var(--wp--preset--font-family--eb-garamond)",
 					"fontSize": "var(--wp--custom--pullquote--typography--font-size)",
-					"fontWeight": 400,
+					"fontWeight": "400",
 					"lineHeight": "var(--wp--custom--pullquote--typography--line-height)"
 				}
 			},
@@ -834,8 +834,8 @@
 					"fontFamily": "var(--wp--preset--font-family--eb-garamond)",
 					"fontSize": "30px",
 					"fontStyle": "normal",
-					"fontWeight": 400,
-					"lineHeight": 1.3
+					"fontWeight": "400",
+					"lineHeight": "1.3"
 				}
 			}
 		},

--- a/source/wp-content/themes/wporg-parent-2021/theme.json
+++ b/source/wp-content/themes/wporg-parent-2021/theme.json
@@ -533,8 +533,8 @@
 				},
 				{
 					"name": "Small",
-					"slug": 40,
-					"size": "40px"
+					"slug": "40",
+					"size": "clamp(30px, calc(100vw / 19), 50px)"
 				},
 				{
 					"name": "Medium",
@@ -543,8 +543,8 @@
 				},
 				{
 					"name": "Large",
-					"slug": 60,
-					"size": "clamp( 20px, calc( 100vw / 18 ), 80px )"
+					"slug": "60",
+					"size": "clamp(20px, calc(10vw + -40px), 80px)"
 				},
 				{
 					"name": "X-Large",

--- a/source/wp-content/themes/wporg-parent-2021/theme.json
+++ b/source/wp-content/themes/wporg-parent-2021/theme.json
@@ -534,17 +534,17 @@
 				{
 					"name": "Small",
 					"slug": "40",
-					"size": "clamp(30px, calc(100vw / 19), 50px)"
+					"size": "clamp(30px, 5vw, 50px)"
 				},
 				{
 					"name": "Medium",
 					"slug": "50",
-					"size": "clamp(40px, calc(100vw / 16), 60px)"
+					"size": "clamp(40px, calc(5vw + 10px), 60px)"
 				},
 				{
 					"name": "Large",
 					"slug": "60",
-					"size": "clamp(20px, calc(10vw + -40px), 80px)"
+					"size": "clamp(20px, calc(10vw - 40px), 80px)"
 				},
 				{
 					"name": "X-Large",
@@ -554,12 +554,12 @@
 				{
 					"name": "2X-Large",
 					"slug": "80",
-					"size": "clamp(80px, calc(100vw / 7), 120px)"
+					"size": "clamp(80px, calc(6.67vw + 40px), 120px)"
 				},
 				{
 					"name": "3X-Large",
 					"slug": "90",
-					"size": "clamp(80px, calc(100vw / 7), 160px)"
+					"size": "clamp(80px, 13.33vw, 160px)"
 				}
 			]
 		},


### PR DESCRIPTION
See #105 — The new designs use flexible spacing, the [values are described in this codepen](https://codepen.io/joen/pen/ZEVOzZK?editors=1100). The new spacing variables are almost identical to the existing values, with some minor changes.

- Small: not actually listed in the codepen, but I noticed a bunch of places that used a 30/50 scale so I've mapped that to this value. It's `--wp--preset--spacing--40: clamp(30px, 5vw, 50px);`
- Large: This was set to be 20/80 scale using the same values as production, but I felt the scale was off, too broad— it wouldn't reach 80px until 1440px wide, and wouldn't hit 20px until 360px wide, which is pretty small for modern phones. I've changed this scale to be more consistent across the variables, so now it starts at 20px until 600px, and scales until it hits 80px at a 1000px viewport.
- Medium, 2X-Large, 3X-Large: These were also tweaked so that the scale has more consistent breakpoints, and so the scale value is simplified.

I've also updated [the docs for these values](https://github.com/WordPress/wporg-parent-2021/blob/eac2d06211a59377d09bb193887cfadbf0f7bdb5/readme.md#spacing).

**Before & After values at different sizes**

<details>
<summary>At 450px wide</summary>

| Name         | Before | After |
|--------------|--------|-------|
| Small        |   40px |  30px |
| Medium       |   40px |  40px |
| Large        |   25px |  20px |
| 2X-Large     |   80px |  80px |
| 3X-Large     |   80px |  80px |

</details>

<details>
<summary>At 800px wide</summary>

| Name         | Before | After |
|--------------|--------|-------|
| Small        |   40px |  40px |
| Medium       |   50px |  50px |
| Large        |   44px |  40px |
| 2X-Large     |  114px |  93px |
| 3X-Large     |  114px | 106px |

</details>

<details>
<summary>At 1320px wide</summary>

| Name         | Before | After |
|--------------|--------|-------|
| Small        |   40px |  50px |
| Medium       |   60px |  60px |
| Large        |   73px |  80px |
| 2X-Large     |  120px | 120px |
| 3X-Large     |  160px | 160px |

</details>

<details>
<summary>At 1920px wide</summary>

| Name         | Before | After |
|--------------|--------|-------|
| Small        |   40px |  50px |
| Medium       |   60px |  60px |
| Large        |   80px |  80px |
| 2X-Large     |  120px | 120px |
| 3X-Large     |  160px | 160px |

</details>

### How to test the changes in this Pull Request:

1. Make sure the values still work in the editor
2. Check child themes, make sure nothing is broken
