### PR TITLE
Use LinkWrapper elements for Card Grid styles

### DIFF
--- a/source/wp-content/themes/wporg-parent-2021/sass/block-styles.scss
+++ b/source/wp-content/themes/wporg-parent-2021/sass/block-styles.scss
@@ -210,8 +210,7 @@
 	}
 }
 
-.wp-block-group-is-layout-grid.is-style-cards-grid,
-.wp-block-post-content .wp-block-group-is-layout-grid.is-style-cards-grid {
+.wp-block-group-is-layout-grid.is-style-cards-grid {
 	grid-auto-rows: 1fr;
 
 	@include break-small-only() {

--- a/source/wp-content/themes/wporg-parent-2021/sass/block-styles.scss
+++ b/source/wp-content/themes/wporg-parent-2021/sass/block-styles.scss
@@ -210,10 +210,8 @@
 	}
 }
 
-.is-style-cards-grid,
-// Required to override link styles in the editor
-.wp-block-post-content .is-style-cards-grid {
-	display: grid;
+.wp-block-group-is-layout-grid.is-style-cards-grid,
+.wp-block-post-content .wp-block-group-is-layout-grid.is-style-cards-grid {
 	grid-auto-rows: 1fr;
 
 	@include break-small-only() {
@@ -221,35 +219,33 @@
 		grid-auto-rows: unset;
 	}
 
-	> * {
-		display: flex;
+	.wp-block-wporg-link-wrapper {
+		padding: var(--wp--preset--spacing--20);
+		border: 1px solid var(--wp--preset--color--light-grey-1);
+		color: var(--wp--preset--color--charcoal-1);
+		border-radius: 2px;
 
-		> a {
-			flex: 1 1 auto;
-			padding: var(--wp--preset--spacing--20);
-			border: 1px solid var(--wp--preset--color--light-grey-1);
-			text-decoration: none;
-			color: var(--wp--preset--color--charcoal-1);
-			border-radius: 2px;
+		h2,
+		h3,
+		h4,
+		h5,
+		h6 {
+			margin-top: 0;
+			margin-bottom: calc(var(--wp--preset--spacing--10) / 2);
+			color: var(--wp--custom--link--color--text);
+		}
 
-			strong {
-				display: block;
-				margin-bottom: calc(var(--wp--preset--spacing--10) / 2);
-				color: var(--wp--custom--link--color--text);
-			}
+		p {
+			margin-top: 0;
+		}
 
-			&:hover {
-				background-color: var(--wp--preset--color--light-grey-2);
-			}
+		&:hover {
+			background-color: var(--wp--preset--color--light-grey-2);
+			text-decoration: none !important;
+		}
 
-			&:focus {
-				border-color: transparent;
-			}
-
-			&:focus-visible {
-				outline: 1.5px solid var(--wp--preset--color--blueberry-1);
-				outline-offset: -1.5px;
-			}
+		&:focus-visible {
+			border-color: transparent;
 		}
 	}
 }


### PR DESCRIPTION
Closes #109, see issue for further explanation.

Changes expected markup for children of a card grid from a single element with a nested anchor, to a LinkWrapper with a nested heading and paragraph element, like the design suggests:

![Screenshot 2023-09-22 at 4 51 28 PM](https://github.com/WordPress/wporg-parent-2021/assets/1017872/5a971aa8-77e7-47c8-b1b7-8486c121a391)

This markup isn't possible with core blocks, but luckily we have already developed the LinkWrapper block to handle cards like this.

No visual changes.

### How to test the changes in this Pull Request:

This PR can be tested via the corresponding Developer update PRs; [CLI](https://github.com/WordPress/wporg-developer/pull/288) and [Home](https://github.com/WordPress/wporg-developer/pull/290)