### PR TITLE
Add Borderless table style

### DIFF
--- a/source/wp-content/themes/wporg-parent-2021/inc/block-styles.php
+++ b/source/wp-content/themes/wporg-parent-2021/inc/block-styles.php
@@ -190,6 +190,14 @@ function setup_block_styles() {
 			'label'        => __( 'Cards Grid', 'wporg' ),
 		)
 	);
+
+	register_block_style(
+		'core/table',
+		array(
+			'name'         => 'borderless',
+			'label'        => __( 'Borderless', 'wporg' ),
+		)
+	);
 }
 
 /**

--- a/source/wp-content/themes/wporg-parent-2021/sass/blocks/_table.scss
+++ b/source/wp-content/themes/wporg-parent-2021/sass/blocks/_table.scss
@@ -27,3 +27,35 @@
 		background-color: transparent;
 	}
 }
+
+.wp-block-table.is-style-borderless {
+	thead {
+		border-bottom: none;
+
+		tr {
+			background-color: var(--wp--preset--color--blueberry-4);
+		}
+
+		th {
+			font-weight: 700;
+		}
+	}
+
+	tbody {
+		tr {
+			&:nth-child(2n) {
+				background-color: var(--wp--preset--color--light-grey-2);
+			}
+
+			&:nth-child(2n+1) {
+				background-color: transparent;
+			}
+		}
+	}
+
+	thead th,
+	tbody td {
+		border: none;
+		padding: var(--wp--preset--spacing--10);
+	}
+}


### PR DESCRIPTION
Borderless table style is required for handbook tables in the redesigned Developer site.

Closes #113

### Screenshots

<!-- If your change has a visual component, add a screenshot here. -->

| Editor | ![Screenshot 2023-10-20 at 10 46 33 AM](https://github.com/WordPress/wporg-parent-2021/assets/1017872/5a77a28d-8b36-4f58-87c5-2b5a3da8a003) |
|--------|-------|
| Frontend | ![Screenshot 2023-10-20 at 10 46 49 AM](https://github.com/WordPress/wporg-parent-2021/assets/1017872/fa6b2012-3239-478a-a95d-1a530fc5a72b) |

### How to test the changes in this Pull Request:

1. Add a table and choose the Borderless style
2. Check against [design](https://www.figma.com/file/2WxlJFzMJvqPfZL1EkAOVp/Developer-Resources?node-id=2934%3A7550&mode=dev)