### PR TITLE
Add `wporg-parent-block-styles` as dependency of parent stylesheet

### DIFF
--- a/source/wp-content/themes/wporg-parent-2021/functions.php
+++ b/source/wp-content/themes/wporg-parent-2021/functions.php
@@ -74,7 +74,7 @@ function enqueue_assets() {
 	wp_enqueue_style(
 		'wporg-parent-2021-style',
 		get_template_directory_uri() . '/build/style.css',
-		array( 'wporg-global-fonts' ),
+		array( 'wporg-global-fonts', 'wporg-parent-block-styles' ),
 		filemtime( __DIR__ . '/build/style.css' )
 	);
 	wp_style_add_data( 'wporg-parent-2021-style', 'rtl', 'replace' );


### PR DESCRIPTION
The block stylesheet is no longer implicitly enqueued after updating Core from `6.4-alpha-56702` to `6.5-alpha-57108`. That caused some styles on `wordpress.org/download/` and `developer.wordpress.org/redesign-test/` to disappear.

Related: `r21248-dotorg`
 
Props @adamwoodnz 