### PR TITLE
Add IBM Plex Sans to font families

### DIFF
--- a/source/wp-content/themes/wporg-parent-2021/theme.json
+++ b/source/wp-content/themes/wporg-parent-2021/theme.json
@@ -601,6 +601,11 @@
 					"fontFamily": "'IBM Plex Mono', monospace",
 					"slug": "monospace",
 					"name": "Monospace"
+				},
+				{
+					"fontFamily": "'IBM Plex Sans', san-serif",
+					"slug": "ibm-plex-sans",
+					"name": "IBM Plex Sans"
 				}
 			],
 			"fontSizes": [


### PR DESCRIPTION
Required for Developers site.

See https://github.com/WordPress/wporg-developer/issues/374

Depends on https://github.com/WordPress/wporg-mu-plugins/pull/509

See it in action on https://github.com/WordPress/wporg-developer/pull/377