### PR TITLE
Enhance content wrapping with `text-wrap`

### DIFF
--- a/source/wp-content/themes/wporg-parent-2021/sass/base/_elements.scss
+++ b/source/wp-content/themes/wporg-parent-2021/sass/base/_elements.scss
@@ -1,3 +1,23 @@
+// Create balanced text blocks
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+caption,
+figcaption {
+	text-wrap: var(--wp--custom--heading--typography--text-wrap);
+}
+
+// Prevent orphans
+p,
+ul,
+ol,
+blockquote {
+	text-wrap: var(--wp--custom--body--typography--text-wrap);
+}
+
 // Links
 a {
 	cursor: pointer;

--- a/source/wp-content/themes/wporg-parent-2021/theme.json
+++ b/source/wp-content/themes/wporg-parent-2021/theme.json
@@ -283,7 +283,8 @@
 			},
 			"body": {
 				"typography": {
-					"lineHeight": 1.875
+					"lineHeight": 1.875,
+					"textWrap": "pretty"
 				},
 				"short-text": {
 					"typography": {
@@ -328,7 +329,8 @@
 				"typography": {
 					"fontFamily": "var(--wp--preset--font-family--eb-garamond)",
 					"fontWeight": 400,
-					"lineHeight": 1.3
+					"lineHeight": 1.3,
+					"textWrap": "balance"
 				},
 				"cta": {
 					"typography": {


### PR DESCRIPTION
Closes #118 

`text-wrap: balance` for headings and captions, results in harmonious text blocks.
`text-wrap: pretty` for longer form content, prevents orphans.

### Screenshots

#### Before 
![text wrap before](https://github.com/WordPress/wporg-parent-2021/assets/1017872/720944a4-558d-405a-b621-1e25b20cc020)

#### After
![text wrap after](https://github.com/WordPress/wporg-parent-2021/assets/1017872/29ae0452-3028-4e06-8e14-7004de0b42fc)

### How to test the changes in this Pull Request:

Test various sites with child themes of this theme ([Main](https://github.com/WordPress/wporg-main-2022), [Developer](https://github.com/WordPress/wporg-developer), [Showcase](https://github.com/WordPress/wporg-showcase-2022), [Documentation](https://github.com/WordPress/wporg-documentation-2022), [Events](https://github.com/WordPress/wordcamp.org/tree/production/public_html/wp-content/themes/wporg-events-2023)), ensuring your parent theme is on this branch and built.

Check the tags targeted, and see how they respond to different screen widths.

Check browsers that don't support the properties yet (Safari and Firefox at time of writing), they should gracefully degrade, ie. there should be no effect.
https://caniuse.com/?search=text-wrap%3Apretty
https://caniuse.com/?search=text-wrap%3Abalance