### PR TITLE
Rosetta: Enable locale-specific customizations to theme.json settings.

### DIFF
--- a/source/wp-content/themes/wporg-parent-2021/functions.php
+++ b/source/wp-content/themes/wporg-parent-2021/functions.php
@@ -8,6 +8,7 @@ defined( 'WPINC' ) || die();
 
 require_once __DIR__ . '/inc/gutenberg-tweaks.php';
 require_once __DIR__ . '/inc/block-styles.php';
+require_once __DIR__ . '/inc/rosetta-styles.php';
 
 /**
  * Actions and filters.

--- a/source/wp-content/themes/wporg-parent-2021/inc/rosetta-styles.php
+++ b/source/wp-content/themes/wporg-parent-2021/inc/rosetta-styles.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * Rosetta customizations.
+ */
+
+namespace WordPressdotorg\Theme\Parent_2021\Rosetta_Styles;
+
+defined( 'WPINC' ) || die();
+
+add_filter( 'wp_theme_json_data_user', __NAMESPACE__ . '\inject_i18n_customizations' );
+
+/**
+ * Inject customizations for Rosetta sites.
+ *
+ * @param WP_Theme_JSON_Data $theme_json Class to access and update the underlying data.
+ *
+ * @return WP_Theme_JSON_Data The updated user settings.
+ */
+function inject_i18n_customizations( $theme_json ) {
+	$locale_settings = get_locale_customizations( get_locale() );
+	if ( ! $locale_settings ) {
+		return $theme_json;
+	}
+
+	$config = array(
+		'version' => 2,
+		'settings' => $locale_settings,
+	);
+
+	return new \WP_Theme_JSON( $config, 'custom' );
+}
+
+/**
+ * Get a theme.json-shaped array with custom values for a given locale.
+ *
+ * The returned array should match the structure of "settings" in a theme.json
+ * file. These will be loaded as the "user" settings, which will override the
+ * theme.json values. Rosetta sites can then override any of the generated
+ * custom properties (ex, --wp--preset--font-size--normal) in a way that will
+ * cascade to any future child themes, and also render correctly in the editor.
+ *
+ * @param string $locale The current site locale.
+ *
+ * @return array An array of settings mirroring a theme.json "settings" object.
+ */
+function get_locale_customizations( $locale ) {
+	switch ( $locale ) {
+		case 'ca':
+		case 'fr':
+		case 'it_IT':
+		case 'ro_RO':
+			return [
+				'typography' => [
+					'fontSizes' => [
+						[
+							'slug' => 'heading-cta',
+							'size' => '96px',
+						],
+					],
+				],
+			];
+		case 'ja':
+			return [
+				'custom' => [
+					'heading' => [
+						'cta' => [
+							'breakpoint' => [
+								'small-only' => [
+									'typography' => [
+										'fontSize' => '50px',
+									],
+								],
+							],
+						],
+					],
+				],
+				'typography' => [
+					'fontSizes' => [
+						[
+							'slug' => 'heading-cta',
+							'size' => '96px',
+						],
+						[
+							'slug' => 'heading-2',
+							'size' => '40px',
+						],
+					],
+				],
+			];
+	}
+	return false;
+}


### PR DESCRIPTION
Add a method for overriding the default parent theme settings for rosetta sites. This will allow polyglots teams to provide, for example, preferred font sizes, which they or a meta dev can then code into the `get_locale_customizations` function using a `theme.json` format, so that any values [defined in settings](https://github.com/WordPress/wporg-parent-2021/blob/0b014ed6fe5b954e53afa046d9b278d1cd54463e/source/wp-content/themes/wporg-parent-2021/theme.json#L5-L682) can be adjusted. While the entire object can be updated (so that locales can also control the responsive sizes and line heights), some things like colors will likely not be allowed to change.

This PR works in tandem with https://github.com/WordPress/wporg-main-2022/pull/380, which adds a new CSS file for specific rosetta site overrides.

In practice, I see this working like so:

- Polyglots test out the theme with `https://[locale].wordpress.org/?new-theme=1`
- Notice some typography/alignment/spacing does not work well.
- Make an issue in wporg-main-2022 describing the issue.
- If the issue is page or section specific, a dev can make a PR to add CSS (like in https://github.com/WordPress/wporg-main-2022/pull/380).
- If the issue is more general, like universally font sizes should be smaller, the change should be made here to apply to all future sites as well.

If we end up with many customization requests, we could look at providing a UI for polyglots teams to manage this themselves, but I'd like to start here first.

❓ **Review question:** Is `get_locale()` the best thing to `switch` on, or is there a better, rosetta-specific function I should use?

See https://github.com/WordPress/wporg-main-2022/issues/266, Fixes https://github.com/WordPress/wporg-main-2022/issues/306

### Screenshots

I took a number of screenshots (with an automated script), you can [look through the whole batch here](https://cloudup.com/cy-tJdkZ-bB).

**Homepage**

In Catalan (and fr, it, ro), the heading CTA font is smaller (first two sections, community section, get started). In Japanese, the heading CTA and heading-2 fonts are smaller (all other headings).

| Locale | Before | After |
|-------|--------|-------|
| English (UK) | ![home-en-gb-before](https://github.com/WordPress/wporg-parent-2021/assets/541093/320540fe-c5c7-4cb6-8036-c40330d9e7fa) | ![home-en-gb-after](https://github.com/WordPress/wporg-parent-2021/assets/541093/42b0d35b-6b7a-4a10-8401-c55a0afcb41b) |
| Catalan | ![home-ca-before](https://github.com/WordPress/wporg-parent-2021/assets/541093/67bb7870-7c99-473b-8257-b7c61124fad0) | ![home-ca-after](https://github.com/WordPress/wporg-parent-2021/assets/541093/acc35ccc-9c3b-44af-9c8e-745ccf94da0b) |
| Japanese | ![home-ja-before](https://github.com/WordPress/wporg-parent-2021/assets/541093/b8dde962-a7f5-43d1-b91b-8c616995d52e) | ![home-ja-after](https://github.com/WordPress/wporg-parent-2021/assets/541093/d2e3fb60-b3c1-47a6-b170-7a642b2450bf) |

**Download page**

Here, you can see the heading-2 size difference in the last two sections.

| Before | After |
|--------|-------|
| ![download-ja-before](https://github.com/WordPress/wporg-parent-2021/assets/541093/80539f0c-31fe-4437-80d2-453725b8a0a1) | ![download-ja-after](https://github.com/WordPress/wporg-parent-2021/assets/541093/4880b372-bff1-4ef7-813a-f88a15061522) |

### How to test the changes in this Pull Request:

You can test localized sites by [following the instructions on wporg-main-2022](https://github.com/WordPress/wporg-main-2022#working-on-non-english-sites).

I also tested this on my sandbox with the [top completed languages](https://translate.wordpress.org/projects/meta/wordpress-org/) for wporg.

After that, just clicking around pages and making sure they look okay. What I used:

- Home: '/'
- Download: '/download/'
- A download subpage: '/download/source/'
- About: '/about/'
- An about subpage: '/about/etiquette/'
- News: '/news/'