### PR TITLE
Unset heading text-wrap for ja

### DIFF
--- a/source/wp-content/themes/wporg-parent-2021/inc/rosetta-styles.php
+++ b/source/wp-content/themes/wporg-parent-2021/inc/rosetta-styles.php
@@ -72,6 +72,9 @@ function get_locale_customizations( $locale ) {
 								],
 							],
 						],
+						'typography' => [
+							'text-wrap' => 'unset',
+						],
 					],
 				],
 				'typography' => [


### PR DESCRIPTION
In https://github.com/WordPress/wporg-parent-2021/pull/119 `text-wrap` was implemented.

However since this is causing unexpected line break especially on headers in Japanese like https://github.com/WordPress/wporg-parent-2021/pull/120#issuecomment-1897700115 , I unset the css variable. 
Chinese and Korean probably has the same issue but it is out of this scope since I'm a stranger.

cc @t-hamano

### Screenshots

<!-- If your change has a visual component, add a screenshot here. -->

| Before | After |
|--------|-------|
| ![localhost_8898_2024_01_hello-world_](https://github.com/WordPress/wporg-parent-2021/assets/8445575/224031d7-1fcb-4ea8-b1e2-d040978848ce) | ![localhost_8898_2024_01_hello-world_ (1)](https://github.com/WordPress/wporg-parent-2021/assets/8445575/7472d608-0e74-46e5-b6d8-d3f50248c02a) |

FYI this change was discussed in the [Japanese Slack](https://wpja.slack.com/archives/CCSPW7GE4/p1706075885883299?thread_ts=1705548098.189659&cid=CCSPW7GE4).
