### PR TITLE
Add custom code border radius

### DIFF
--- a/source/wp-content/themes/wporg-parent-2021/theme.json
+++ b/source/wp-content/themes/wporg-parent-2021/theme.json
@@ -143,6 +143,11 @@
 			"alignment": {
 				"alignedMaxWidth": "50%"
 			},
+			"code": {
+				"border": {
+					"radius": "2px"
+				}
+			},
 			"button": {
 				"color": {
 					"background": "var(--wp--preset--color--blueberry-1)",


### PR DESCRIPTION
As discussed in https://github.com/WordPress/wporg-developer/pull/447#discussion_r1461717206, a custom code block style is added for better semantics.

Please test with https://github.com/WordPress/wporg-developer/pull/447