### PR TITLE
Block Styles: Add "Buttons" block style for navigation block

### DIFF
--- a/source/wp-content/themes/wporg-parent-2021/inc/block-styles.php
+++ b/source/wp-content/themes/wporg-parent-2021/inc/block-styles.php
@@ -198,6 +198,15 @@ function setup_block_styles() {
 			'label'        => __( 'Borderless', 'wporg' ),
 		)
 	);
+
+	register_block_style(
+		'core/navigation',
+		array(
+			'name'         => 'button-list',
+			'label'        => __( 'Buttons', 'wporg' ),
+			'style_handle' => STYLE_HANDLE,
+		)
+	);
 }
 
 /**

--- a/source/wp-content/themes/wporg-parent-2021/sass/blocks/_button.scss
+++ b/source/wp-content/themes/wporg-parent-2021/sass/blocks/_button.scss
@@ -112,4 +112,40 @@
 			box-shadow: inset 0 0 0 3px var(--wp--custom--button--outline--hover--border--color);
 		}
 	}
+
+	// Block style for navigation, but uses button style mixins.
+	&.is-style-button-list {
+		gap: 0;
+
+		.wp-block-navigation-item__content {
+			--wp--custom--button--outline--border--color: transparent !important;
+			border-radius: 2px;
+
+			&:hover,
+			&:focus {
+				text-decoration: none;
+			}
+
+			&:focus {
+
+				@include button-color-focus-styles;
+			}
+
+			@include button-small-styles;
+			@include button-toggle-styles;
+		}
+
+		.current-menu-item .wp-block-navigation-item__content {
+
+			@include button-toggle-active-styles;
+
+			--wp--custom--button--outline--hover--color--text: var(--wp--preset--color--white);
+			--wp--custom--button--outline--focus--color--background: var(--wp--preset--color--charcoal-1);
+
+			&:hover {
+				--wp--custom--button--outline--hover--color--text: var(--wp--preset--color--charcoal-1);
+				--wp--custom--button--outline--hover--color--background: var(--wp--preset--color--light-grey-1);
+			}
+		}
+	}
 }

--- a/source/wp-content/themes/wporg-parent-2021/sass/blocks/_button.scss
+++ b/source/wp-content/themes/wporg-parent-2021/sass/blocks/_button.scss
@@ -119,6 +119,8 @@
 
 		.wp-block-navigation-item__content {
 			--wp--custom--button--outline--border--color: transparent !important;
+			--wp--custom--button--outline--hover--border--color: var(--wp--preset--color--light-grey-2) !important;
+			--wp--custom--button--outline--hover--color--background: var(--wp--preset--color--light-grey-2) !important;
 			border-radius: 2px;
 
 			&:hover,
@@ -144,7 +146,7 @@
 
 			&:hover {
 				--wp--custom--button--outline--hover--color--text: var(--wp--preset--color--charcoal-1);
-				--wp--custom--button--outline--hover--color--background: var(--wp--preset--color--light-grey-1);
+				--wp--custom--button--outline--hover--color--background: var(--wp--preset--color--light-grey-2);
 			}
 		}
 	}

--- a/source/wp-content/themes/wporg-parent-2021/sass/blocks/_button.scss
+++ b/source/wp-content/themes/wporg-parent-2021/sass/blocks/_button.scss
@@ -116,6 +116,8 @@
 	// Block style for navigation, but uses button style mixins.
 	&.is-style-button-list {
 		gap: 0;
+		overflow-x: auto;
+		white-space: nowrap;
 
 		.wp-block-navigation-item__content {
 			--wp--custom--button--outline--border--color: transparent !important;


### PR DESCRIPTION
See https://github.com/WordPress/pattern-directory/issues/635 — The category navigation uses a row of links, so a navigation block is appropriate for the markup, but the individual items use "button" styles for active (and presumably hover/focus, though not mocked up there).

I've added this to the parent theme for two reasons: I thought this pattern might pop up again, maybe in plugins, and I wanted to easily share the block mixin code.

### Screenshots

In the first set of screenshots, "Featured" is in the hover state, and "Posts" is currently selected. In the second, we're on the homepage so no current selection, and "Featured" is in the focus state.

| Before | After |
|--------|-------|
| <img width="819" alt="before" src="https://github.com/WordPress/wporg-parent-2021/assets/541093/8e8ccd93-6f1b-41d9-92c5-4d19470aee2a"> | <img width="844" alt="after" src="https://github.com/WordPress/wporg-parent-2021/assets/541093/4eef3d51-27d9-42a2-aeb1-c6340f314934"> |
| <img width="747" alt="before" src="https://github.com/WordPress/wporg-parent-2021/assets/541093/f4e03b2d-708d-4603-a279-9c2c7cf2b556"> | <img width="805" alt="after" src="https://github.com/WordPress/wporg-parent-2021/assets/541093/33b35465-c017-48ec-9055-89ed43e8eab0"> |

cc @WordPress/meta-design Do those interaction states work?

### How to test the changes in this Pull Request:

1. Add a navigation block (in a post, page, or the site editor)
2. Switch to the styles tab & select "Buttons"
3. There won't be much of a change in the editor, but on the frontend the navigation links should behave more like buttons: there is padding around them, the background changes on hover, and the currently-selected item should have a black background.
4. If you're testing in a post/page, add the current page to the menu to check the current selected state.
