### PR TITLE
Change the color of visited links to purple

### DIFF
--- a/source/wp-content/themes/wporg-parent-2021/sass/base/_elements.scss
+++ b/source/wp-content/themes/wporg-parent-2021/sass/base/_elements.scss
@@ -31,11 +31,11 @@ a {
 	&:focus {
 		text-decoration-line: none;
 	}
+}
 
-	&:where(:not(.wp-element-button)) {
-		&:visited {
-			color: var(--wp--preset--color--purple-1);
-		}
+:where(.entry-content a:not(.wp-element-button)) {
+	&:visited {
+		color: var(--wp--preset--color--purple-1);
 	}
 }
 

--- a/source/wp-content/themes/wporg-parent-2021/sass/base/_elements.scss
+++ b/source/wp-content/themes/wporg-parent-2021/sass/base/_elements.scss
@@ -31,6 +31,12 @@ a {
 	&:focus {
 		text-decoration-line: none;
 	}
+
+	&:where(:not(.wp-element-button)) {
+		&:visited {
+			color: var(--wp--preset--color--purple-1);
+		}
+	}
 }
 
 // Text highlighted via the editor

--- a/source/wp-content/themes/wporg-parent-2021/theme.json
+++ b/source/wp-content/themes/wporg-parent-2021/theme.json
@@ -139,8 +139,18 @@
 				},
 				{
 					"slug": "purple-1",
-					"color": "#7a00df",
+					"color": "#5300be",
 					"name": "Purple 1"
+				},
+				{
+					"slug": "purple-2",
+					"color": "#7a00df",
+					"name": "Purple 2"
+				},
+				{
+					"slug": "purple-3",
+					"color": "#d7a7ff",
+					"name": "Purple 3"
 				}
 			]
 		},

--- a/source/wp-content/themes/wporg-parent-2021/theme.json
+++ b/source/wp-content/themes/wporg-parent-2021/theme.json
@@ -136,6 +136,11 @@
 					"slug": "lemon-3",
 					"color": "#fffdd6",
 					"name": "Lemon 3"
+				},
+				{
+					"slug": "purple-1",
+					"color": "#7a00df",
+					"name": "Purple 1"
 				}
 			]
 		},


### PR DESCRIPTION
Changes the color of all links which are not buttons to a new purple color, added to the palette.

This has wide ranging effects and will need to be overridden in some cases. I've drafted [a corresponding mu-plugins PR](https://github.com/WordPress/wporg-mu-plugins/pull/595) for some of these, but it will probably need to be more expansive, see screenshots below.

Closes #128 
Related https://github.com/WordPress/wporg-mu-plugins/pull/595

### Screenshots (with local nav and breadcrumb overrides applied)

| Developer | Showcase | Forums |
|--------|-------|-|
| ![developer wordpress org_block-editor_getting-started_devenv_nodejs-development-environment_(2 1366x768)](https://github.com/WordPress/wporg-parent-2021/assets/1017872/23a75d60-bd82-4433-87cc-e9528aaef05f) | ![wordpress org_showcase_(2 1366x768)](https://github.com/WordPress/wporg-parent-2021/assets/1017872/1e7731ff-57f4-4a18-8c4d-de026d366224) | ![wordpress org_support_forum_installation_(Desktop)](https://github.com/WordPress/wporg-parent-2021/assets/1017872/7829d2a9-2490-4d9a-a782-3b6c79bd9dc5) |

| Main | Documentation |
|--------|-------|
| ![wordpress org_(2 1366x768)](https://github.com/WordPress/wporg-parent-2021/assets/1017872/745ac6d4-0dc9-4e9a-b6d2-400afaae113d) | ![wordpress org_documentation_(Desktop)](https://github.com/WordPress/wporg-parent-2021/assets/1017872/97e1a03e-5259-465d-8c38-20f139d7485a) |

### How to test the changes in this Pull Request:

1. Build the styles
2. Test with dependent child themes; HelpHub, DevHub, Showcase, Main, etc
3. Visit links and observe the style afterward