### PR TITLE
Add gap to `is-style-button-list`.

### DIFF
--- a/source/wp-content/themes/wporg-parent-2021/sass/blocks/_button.scss
+++ b/source/wp-content/themes/wporg-parent-2021/sass/blocks/_button.scss
@@ -115,7 +115,7 @@
 
 	// Block style for navigation, but uses button style mixins.
 	&.is-style-button-list {
-		gap: 0;
+		gap: 6px;
 		overflow-x: auto;
 		white-space: nowrap;
 


### PR DESCRIPTION
This PR adds a gap to the buttons introduced in #127. The buttons currently have a border-radius and when they are side by side it doesn't look great. I chose `6px` because its the smallest value where the gap is visible and won't have a tremendous impact on the width of the nav in the pattern directory. 

### Screenshots

| Before | After |
|--------|-------|
| <img width="234" alt="Screenshot 2024-04-05 at 3 06 30 PM" src="https://github.com/WordPress/wporg-parent-2021/assets/1657336/5eca0216-e1ed-41e7-87a6-9b80a6886012">  | <img width="274" alt="Screenshot 2024-04-05 at 3 06 22 PM" src="https://github.com/WordPress/wporg-parent-2021/assets/1657336/f5947d98-319b-44bc-b803-af16e6780259"> |
