### PR TITLE
Add cursor: pointer for `<button>`s.

### DIFF
--- a/source/wp-content/themes/wporg-parent-2021/sass/blocks/_button-mixins.scss
+++ b/source/wp-content/themes/wporg-parent-2021/sass/blocks/_button-mixins.scss
@@ -4,6 +4,7 @@
 	@include button-typography-styles;
 	@include button-color-styles;
 	border-radius: var(--wp--custom--button--border--radius);
+	cursor: pointer;
 }
 
 @mixin button-color-styles {


### PR DESCRIPTION
I'm working on [Accessibility: Plugin single links and buttons missing hover states #263](https://github.com/WordPress/wordpress.org/issues/263). 

That converted classic to block theme uses `<button>` and `<input>` elements in various places for form submission. 

In order to make those look the same as the new parent style, we've added `wp-block-button__link` to the elements and visual they are working.  👍 

The only difference is that we have `cursor: pointer` added to [anchor](https://github.com/WordPress/wporg-parent-2021/blob/7a7464cd6c3cf5b9ca87c09d8f68fa3182d944fd/source/wp-content/themes/wporg-parent-2021/sass/base/_elements.scss#L25) tags in this parent theme and therefore we get inconsistent hover states between `<a>` and `<button|input>` links.

This PR adds the `cursor: pointer` to the button as well. I can't think of a scenario where this wouldn't make sense.



