### PR TITLE
Change heading size in Japanese locale

### DIFF
--- a/source/wp-content/themes/wporg-parent-2021/inc/rosetta-styles.php
+++ b/source/wp-content/themes/wporg-parent-2021/inc/rosetta-styles.php
@@ -84,6 +84,10 @@ function get_locale_customizations( $locale ) {
 							'size' => '96px',
 						],
 						[
+							'slug' => 'heading-1',
+							'size' => '60px',
+						],
+						[
 							'slug' => 'heading-2',
 							'size' => '40px',
 						],


### PR DESCRIPTION
Partially addresses https://github.com/WordPress/wporg-main-2022/issues/432

> ### News-Single
> - Specify font for h1 (Noto serif jp), font size 60px

Props @nukaga

This PR changes the size of Heading 1 from 70px to 60px in the Japanese locale. As far as I know, this change affects post titles and page titles.

### Screenshots

### Post

| Before | After |
|--------|-------|
| ![image](https://github.com/WordPress/wporg-parent-2021/assets/54422211/36e6834b-c453-4700-87d5-c30290e228e1) | ![image](https://github.com/WordPress/wporg-parent-2021/assets/54422211/7d60c259-85a6-45f9-a38e-3d8ffff536e2) |

### Page

| Header | Header |
|--------|--------|
| ![image](https://github.com/WordPress/wporg-parent-2021/assets/54422211/0440c5b0-fdea-46f6-8703-d592d37d5ba8) | ![image](https://github.com/WordPress/wporg-parent-2021/assets/54422211/83119c4e-adf4-4a72-94f8-0f54cc5599b4) | 

### How to test the changes in this Pull Request:

If you would like to test this PR locally, follow the steps below.

- Create a folder `source/wp-content/languages`, with a `themes` folder inside.
- Download the attachment below, unzip it, and move it to the `source/wp-content/languages/themes` directory.
  [wporg-ja.zip](https://github.com/WordPress/wporg-parent-2021/files/15283627/wporg-ja.zip)
- Create or open the file `.wp-env.override.json`
- Including the new `language` folder and main theme, map it as follows:
  ```
  {
  	"themes": [
  		"./source/wp-content/themes/wporg-parent-2021",
  		"./source/wp-content/themes/wporg-child-2021",
  		"../path/to/wporg-main-2022/source/wp-content/themes/wporg-main-2022"
  	],
  	"mappings": {
  		"env": "./env",
  		"wp-content/mu-plugins": "./source/wp-content/mu-plugins",
  		"wp-content/mu-plugins/0-sandbox.php": "./env/0-sandbox.php",
  		"wp-content/languages": "./source/wp-content/languages"
  	}
  }
  ```