### PR TITLE
Create positioning context for 3 column layout

### DIFF
--- a/source/wp-content/themes/wporg-parent-2021/sass/base/_layout.scss
+++ b/source/wp-content/themes/wporg-parent-2021/sass/base/_layout.scss
@@ -32,6 +32,7 @@
 .has-three-columns {
 	--local--sidebar--width: 248px;
 	--local--column-gap: 40px;
+	position: relative;
 	justify-content: flex-end;
 	max-width: 100%;
 
@@ -45,6 +46,7 @@
 
 	main {
 		order: 1;
+		padding-top: var(--wp--preset--spacing--20);
 	}
 
 	article {
@@ -53,11 +55,12 @@
 
 	// Left sidebar: Typically Chapter List
 	> .wp-block-wporg-sidebar-container {
-		margin-top: var(--wp--preset--spacing--20);
+		padding-top: var(--wp--preset--spacing--20);
 	}
 
 	// Right sidebar: Typically Table of Contents
 	article .wp-block-wporg-sidebar-container {
+		margin-block-start: 0;
 		margin-bottom: var(--wp--preset--spacing--50);
 	}
 
@@ -91,7 +94,9 @@
 			margin-right: auto;
 
 			.wp-block-wporg-sidebar-container {
-				inset-inline-end: var(--wp--preset--spacing--edge-space);
+				padding-top: var(--wp--preset--spacing--20);
+				inset-inline-end: calc((var(--local--block-end-sidebar--width) * -1) - var(--local--column-gap));
+				inset-block: 0;
 			}
 		}
 	}


### PR DESCRIPTION
[Gutenberg 18.5 added `position:relative` to all constrained blocks](https://github.com/WordPress/gutenberg/pull/60347), breaking the 3 column layout.

> I'm not sure if we should unset the position:relative or adjust the top spacing on the sidebar.

I have gone for adjusting the top spacing, but also making the layout less brittle by defining it's own positioning context, and adjusting the position of the children accordingly. It has resulted in just as many changes across the site as if we had unset the relative position everywhere, but I think the end result is simpler, less brittle and moves Documentation forward in terms of redesign.

See https://github.com/WordPress/wporg-parent-2021/issues/139

Props @ryelle 

### How to test the changes in this Pull Request:

Probably easiest to load https://github.com/WordPress/wporg-developer/pull/522 and https://github.com/WordPress/wporg-documentation-2022/pull/97 in sandbox with this and https://github.com/WordPress/wporg-mu-plugins/pull/624

Test the sidebar container position on load and scrolling down. Test a page with a long ToC where it comes into contact with the footer, and check that the height of the sidebar is reduced to avoid overlap.
