### PR TITLE
Remove max-width limit on aligned blocks

### DIFF
--- a/source/wp-content/themes/wporg-parent-2021/sass/base/_layout.scss
+++ b/source/wp-content/themes/wporg-parent-2021/sass/base/_layout.scss
@@ -17,16 +17,6 @@
 	}
 }
 
-@include break-mobile {
-	// limit size of any element that is aligned left/right
-	.wp-block[data-align="left"], // This is for the editor
-	.wp-block[data-align="right"], // This is for the editor
-	.wp-site-blocks .alignleft,
-	.wp-site-blocks .alignright {
-		max-width: var(--wp--custom--alignment--aligned-max-width);
-	}
-}
-
 // Configures a 3 column layout where `wporg/sidebar-container` blocks sit either side of the main content.
 // Examples: Developer Resources, Documentation.
 .has-three-columns {

--- a/source/wp-content/themes/wporg-parent-2021/theme.json
+++ b/source/wp-content/themes/wporg-parent-2021/theme.json
@@ -155,9 +155,6 @@
 			]
 		},
 		"custom": {
-			"alignment": {
-				"alignedMaxWidth": "50%"
-			},
 			"button": {
 				"color": {
 					"background": "var(--wp--preset--color--blueberry-1)",


### PR DESCRIPTION
Closes #141 

Removes the max-width rule set on aligned blocks. This has never been used in our redesign themes and often needs to be overridden, see issue description.

### Testing

Test in sandbox and remove this theme.json override from these themes Developer Resources, Documentation, Learn:

```
"custom": {
	"alignment": {
		"alignedMaxWidth": "$value"
	},
}
```