### PR TITLE
Rosetta styles: Add Noto Serif for Japanese

### DIFF
--- a/source/wp-content/themes/wporg-parent-2021/inc/rosetta-styles.php
+++ b/source/wp-content/themes/wporg-parent-2021/inc/rosetta-styles.php
@@ -78,6 +78,13 @@ function get_locale_customizations( $locale ) {
 					],
 				],
 				'typography' => [
+					'fontFamilies' => [
+						[
+							'fontFamily' => '"Noto Serif JP", serif',
+							'slug' => 'noto-serif-jp',
+							'name' => 'Noto Serif JP',
+						],
+					],
 					'fontSizes' => [
 						[
 							'slug' => 'heading-cta',


### PR DESCRIPTION
This PR simply adds Noto Serif JP as a font available to Japanese Rosetta sites. The font was added by https://github.com/WordPress/wporg-mu-plugins/pull/630, and will be used in wporg-main-2022 https://github.com/WordPress/wporg-main-2022/pull/455.
