### PR TITLE
Button styles: Add `is-destructive` helper class for red buttons

### DIFF
--- a/source/wp-content/themes/wporg-parent-2021/sass/blocks/_button.scss
+++ b/source/wp-content/themes/wporg-parent-2021/sass/blocks/_button.scss
@@ -113,6 +113,50 @@
 		}
 	}
 
+	// Add "destructive" button styles.
+	&.is-destructive {
+		--wp--custom--button--color--text: var(--wp--preset--color--white);
+		--wp--custom--button--color--background: #d6310c;
+		--wp--custom--button--hover--color--background: #b60000;
+		--wp--custom--button--outline--color--text: #d6310c;
+
+		--wp--custom--button--outline--hover--color--text: var(--wp--preset--color--white);
+		--wp--custom--button--outline--hover--color--background: var(--wp--custom--button--outline--color--text);
+		--wp--custom--button--outline--hover--border--color: var(--wp--custom--button--outline--color--text);
+
+		.wp-block-button__link:focus {
+			background-color: var(--wp--custom--button--outline--color--text);
+			color: var(--wp--preset--color--white);
+			outline-color: var(--wp--custom--button--outline--hover--border--color);
+		}
+
+		&.is-style-text .wp-block-button__link:hover {
+			--wp--custom--button--outline--hover--color--text: var(--wp--preset--color--charcoal-1);
+			--wp--custom--button--outline--hover--color--background: var(--wp--preset--color--pomegrade-3);
+			--wp--custom--button--outline--hover--border--color: var(--wp--preset--color--pomegrade-3);
+		}
+
+		&.is-style-fill-on-dark {
+			--wp--custom--button--focus--border--color: var(--wp--preset--color--white);
+			--wp--custom--button--hover--color--background: var(--wp--preset--color--pomegrade-1);
+		}
+
+		&.is-style-outline-on-dark {
+			--wp--custom--button--outline--color--text: var(--wp--preset--color--pomegrade-1);
+
+			.wp-block-button__link:hover {
+				color: var(--wp--preset--color--charcoal-1);
+			}
+
+			.wp-block-button__link:focus {
+				--wp--custom--button--outline--hover--border--color: var(--wp--custom--button--outline--color--text);
+				background-color: var(--wp--custom--button--outline--color--background);
+				color: var(--wp--preset--color--white);
+				outline-color: var(--wp--preset--color--white);
+			}
+		}
+	}
+
 	// Block style for navigation, but uses button style mixins.
 	&.is-style-button-list {
 		gap: 0;


### PR DESCRIPTION
For some designs, we need a "destructive" red button, for example deleting a pattern or reporting a pledge. There isn't a consistent design for this, so for the Pattern Directory, the button uses a toggle style with a custom text color. This doesn't work for other buttons which have blue hover/focus styles— instead we need to create a helper class to set all the respective states.

<img width="202" alt="Screenshot 2024-08-28 at 3 57 22 PM" src="https://github.com/user-attachments/assets/9b625be0-87e3-4b2b-85a5-62cf8ad8732b">
<img width="289" alt="Screenshot 2024-08-28 at 3 56 40 PM" src="https://github.com/user-attachments/assets/e7d3e5a6-784f-4730-b05a-cd42abbf0ceb">

This PR attempts to standardize on a few different reds— pomegrade-1 when contrasting with dark (text or backgrounds), `#d6310c` for the red on white, and `#b60000` as a slightly darker red for filled button hover states.

### Screenshots

<img width="768" alt="Screenshot 2024-08-28 at 3 55 40 PM" src="https://github.com/user-attachments/assets/254f8558-da57-464f-89f3-40223aec0833">

Hover & focus styles:

https://github.com/user-attachments/assets/7d82eed5-f5f4-4bb4-8c06-a1b3fc16794f

**To test**

- Add some button blocks to a page
- In the button's sidebar, open Advanced and add the `is-destructive` class
- The button should be red now 🟥 
- Hover, focus, etc styles should also be red
