### PR TITLE
Increase spacing for h3.

### DIFF
--- a/source/wp-content/themes/wporg-parent-2021/sass/base/_elements.scss
+++ b/source/wp-content/themes/wporg-parent-2021/sass/base/_elements.scss
@@ -163,11 +163,13 @@ input[type="checkbox"] + label {
 
 // Headings.
 // Add margin to default h2 & h3 (no font size changes).
-.wp-site-blocks h2:not([class*="-font-size"], [style*="font-size"]) {
+.wp-site-blocks h2:not([class*="-font-size"], [style*="font-size"]),
+.wp-site-blocks h3:not([class*="-font-size"], [style*="font-size"]) {
 	margin-top: var(--wp--preset--spacing--40);
 }
 
-.wp-site-blocks h3:not([class*="-font-size"], [style*="font-size"]) {
+// Don't add big space if we are preceded by a h2.
+.wp-site-blocks h2 + .wp-site-blocks h3:not([class*="-font-size"], [style*="font-size"]) {
 	margin-top: var(--wp--preset--spacing--30);
 }
 

--- a/source/wp-content/themes/wporg-parent-2021/sass/base/_elements.scss
+++ b/source/wp-content/themes/wporg-parent-2021/sass/base/_elements.scss
@@ -168,7 +168,7 @@ input[type="checkbox"] + label {
 	margin-top: var(--wp--preset--spacing--40);
 }
 
-// Don't add big space if we are preceded by a h2.
+// Make spacing smaller for h3 if preceded by h2.
 .wp-site-blocks h2 + .wp-site-blocks h3:not([class*="-font-size"], [style*="font-size"]) {
 	margin-top: var(--wp--preset--spacing--30);
 }


### PR DESCRIPTION
This PR increases the margin-top for `h3`, but is reversed when it is immediately preceded by an `h2`. It's a pretty subtle change overall originally discussed here: https://wordpress.slack.com/archives/C04U953K77A/p1726018656095909.

## Screenshots

### Not very noticeable in text heavy content
URL: https://wordpress.org/documentation/article/plugins-themes-auto-updates/
| Before | After |
|--------|-------|
| <img width="706" alt="Screenshot 2024-09-12 at 3 36 57 PM" src="https://github.com/user-attachments/assets/bd729d32-4317-4f6a-bffd-63dcb867e1cf">  |  <img width="706" alt="Screenshot 2024-09-12 at 3 36 35 PM" src="https://github.com/user-attachments/assets/c5e0574f-c70d-4587-9064-7f7d2745e380"> |


### More noticeable when elements are combined
URL:  https://developer.wordpress.org/news/2024/08/29/registering-block-templates-via-plugins-in-wordpress-6-7/
| Before | After |
|--------|-------|
| <img width="706" alt="Screenshot 2024-09-12 at 3 39 24 PM" src="https://github.com/user-attachments/assets/711ea933-c71e-41af-be9a-0004cf8c2533">  |  <img width="706" alt="Screenshot 2024-09-12 at 3 39 42 PM" src="https://github.com/user-attachments/assets/74a2b520-6ceb-4797-87e3-eb2bc32d54ff">  |

| Before | After |
|--------|-------|
| <img width="705" alt="Screenshot 2024-09-12 at 3 43 25 PM" src="https://github.com/user-attachments/assets/b3d8b7b5-c7ea-4180-abc2-0e2ef4320886">  |  <img width="706" alt="Screenshot 2024-09-12 at 3 43 36 PM" src="https://github.com/user-attachments/assets/569f3c18-bf25-4fd5-9c10-541bec13f7a8">  |







