### PR TITLE
Make sure we don't use calass. Doesn't work.

### DIFF
--- a/source/wp-content/themes/wporg-parent-2021/sass/base/_elements.scss
+++ b/source/wp-content/themes/wporg-parent-2021/sass/base/_elements.scss
@@ -184,7 +184,7 @@ input[type="checkbox"] + label {
 }
 
 // Make spacing smaller for h3 if preceded by h2.
-.wp-site-blocks h2 + .wp-site-blocks h3:not([class*="-font-size"], [style*="font-size"]) {
+.wp-site-blocks h2 + h3:not([class*="-font-size"], [style*="font-size"]) {
 	margin-top: var(--wp--preset--spacing--30);
 }
 


### PR DESCRIPTION
Follow-up to https://github.com/WordPress/wporg-parent-2021/pull/153.

The next-sibling selector wasn't working. 🥴 
