### PR TITLE
Fix 404 page 'Oops!' text being cut off

### DIFF
--- a/source/wp-content/themes/wporg-parent-2021/sass/page/_404.scss
+++ b/source/wp-content/themes/wporg-parent-2021/sass/page/_404.scss
@@ -1,5 +1,5 @@
 body.error404 {
-	--oops-font-size: 42vw; // "Magic number" ala https://css-tricks.com/fitting-text-to-a-container/
+	--oops-font-size: 47vw; // "Magic number" ala https://css-tricks.com/fitting-text-to-a-container/
 
 	background-color: var(--wp--preset--color--charcoal-2);
 
@@ -31,14 +31,14 @@ body.error404 {
 				z-index: -1;
 				position: absolute;
 				top: 22px;
-				left: -4.9vw;
+				left: -10vw;
 				font-family: var(--wp--preset--font-family--eb-garamond);
 				font-size: var(--oops-font-size);
 				line-height: var(--oops-font-size);
 				opacity: 0.4; // Make the overlaid text more readable.
 
 				@include break-small() {
-					top: calc(var(--oops-font-size) * -0.25);
+					top: calc(var(--oops-font-size) * -0.58);
 				}
 			}
 		}

--- a/source/wp-content/themes/wporg-parent-2021/sass/page/_404.scss
+++ b/source/wp-content/themes/wporg-parent-2021/sass/page/_404.scss
@@ -1,18 +1,10 @@
 body.error404 {
-	--oops-font-size: 47vw; // "Magic number" ala https://css-tricks.com/fitting-text-to-a-container/
+	--oops-font-size: 42vw; // "Magic number" ala https://css-tricks.com/fitting-text-to-a-container/
 
 	background-color: var(--wp--preset--color--charcoal-2);
 
 	.site-content-container {
-
-		/*
-		 * Prevent "oops" from creating a horizontal scroll.
-		 * In some iOS versions, these rules also have to be applied to <html>, but that would bleed over to other
-		 * pages. It's better to just let there be a scroll, since it's not a commonly used page.
-		 */
-		position: relative; // needed for overflow to work
-		overflow: hidden;
-
+		position: relative;
 		z-index: 0;
 
 		@include break-small() {
@@ -108,5 +100,10 @@ body.error404 {
 				fill: currentColor;
 			}
 		}
+	}
+
+	.wp-block-wporg-global-footer {
+		background: unset;
+		z-index: 1;
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/WordPress/wporg-parent-2021/issues/155

I'm not sure what has changed to make this happen, nor do I know what the original design was, so this is an attempt to stop the text being cropped both vertically and horizontally.

| Before 1536x768 |
|--------|
| ![wordpress org_duh(3 1536x864) (1)](https://github.com/user-attachments/assets/fe6811d9-15c9-46b9-815b-dfc39739d70d) | 

### Changes

Adjusts the size of the text so that it fits horizontally, allows overflow to be visible, and adjusts layering so that the footer can overlap the text.

The `overflow: hidden` looks like it was added to stop the page scrolling due to the height of the 'Oops!' text, but I'm not observing that as being a problem. 

### Screenshots of most common screen sizes

| 1920x1080 | 1366x768 | 1536x864 |
|--------|-------|-|
| ![wordpress org_duh(1 1920x1080)](https://github.com/user-attachments/assets/416d970f-aa7d-49cc-98a1-5263a007d280) | ![wordpress org_duh(2 1366x768)](https://github.com/user-attachments/assets/fa3553a1-22fb-4d1f-892a-78bba8066e33) | ![wordpress org_duh(3 1536x864)](https://github.com/user-attachments/assets/de782a22-8982-41d5-a80b-2f6ef85e503c) |

| Tablet portrait | Tablet landscape | Mobile |
|-|-|-|
| ![wordpress org_duh(iPad)](https://github.com/user-attachments/assets/31ece371-332f-496b-9c31-541e5ec9710d) | ![wordpress org_duh(iPad) (1)](https://github.com/user-attachments/assets/09f37d5b-5d98-475a-a660-e3bcd944adc0) | ![wordpress org_duh(Samsung Galaxy S20 Ultra)](https://github.com/user-attachments/assets/ec21702c-82f2-4b06-a7da-62d366a995af) |
