### PR TITLE
Remove the removal of the margin top.

### DIFF
--- a/source/wp-content/themes/wporg-parent-2021/functions.php
+++ b/source/wp-content/themes/wporg-parent-2021/functions.php
@@ -54,9 +54,8 @@ function theme_support() {
 	// Experimental support for adding blocks inside nav menus
 	add_theme_support( 'block-nav-menus' );
 
-	// Remove the default margin-top added when the admin bar is used, this is
-	// handled by the theme, in `_site-header.scss`.
-	add_theme_support( 'admin-bar', array( 'callback' => '__return_false' ) );
+	// Add support for admin bar.
+	add_theme_support( 'admin-bar' );
 
 	register_block_pattern_category(
 		'wporg',

--- a/source/wp-content/themes/wporg-parent-2021/functions.php
+++ b/source/wp-content/themes/wporg-parent-2021/functions.php
@@ -54,9 +54,6 @@ function theme_support() {
 	// Experimental support for adding blocks inside nav menus
 	add_theme_support( 'block-nav-menus' );
 
-	// Add support for admin bar.
-	add_theme_support( 'admin-bar' );
-
 	register_block_pattern_category(
 		'wporg',
 		array(


### PR DESCRIPTION
This relies on https://github.com/WordPress/wporg-mu-plugins/pull/665 and removes code that stops the output of the admin bar top margin.
