### PR TITLE
Theme.json: Add custom properties for Inter Heading font sizes

### DIFF
--- a/source/wp-content/themes/wporg-parent-2021/sass/base/_normalize.scss
+++ b/source/wp-content/themes/wporg-parent-2021/sass/base/_normalize.scss
@@ -48,6 +48,10 @@ body[class] {
 		--wp--preset--font-size--heading-4: var(--wp--custom--heading--level-4--breakpoint--small-only--typography--font-size);
 		--wp--preset--font-size--heading-5: var(--wp--custom--heading--level-5--breakpoint--small-only--typography--font-size);
 		--wp--preset--font-size--heading-6: var(--wp--custom--heading--level-6--breakpoint--small-only--typography--font-size);
+		--wp--custom--heading--level-3--inter--typography--font-size: var(--wp--custom--heading--level-3--inter--breakpoint--small-only--typography--font-size);
+		--wp--custom--heading--level-4--inter--typography--font-size: var(--wp--custom--heading--level-4--inter--breakpoint--small-only--typography--font-size);
+		--wp--custom--heading--level-5--inter--typography--font-size: var(--wp--custom--heading--level-5--inter--breakpoint--small-only--typography--font-size);
+		--wp--custom--heading--level-6--inter--typography--font-size: var(--wp--custom--heading--level-6--inter--breakpoint--small-only--typography--font-size);
 		--wp--preset--font-size--extra-large: var(--wp--custom--body--extra-large--breakpoint--small-only--typography--font-size);
 
 		--wp--custom--heading--cta--typography--line-height: var(--wp--custom--heading--cta--breakpoint--small-only--typography--line-height);

--- a/source/wp-content/themes/wporg-parent-2021/theme.json
+++ b/source/wp-content/themes/wporg-parent-2021/theme.json
@@ -395,6 +395,19 @@
 								"lineHeight": 1.15
 							}
 						}
+					},
+					"inter": {
+						"typography": {
+							"fontSize": "29px",
+							"lineHeight": 1.4
+						},
+						"breakpoint": {
+							"small-only": {
+								"typography": {
+									"fontSize": "21px"
+								}
+							}
+						}
 					}
 				},
 				"level-4": {
@@ -406,6 +419,19 @@
 							"typography": {
 								"fontSize": "22px",
 								"lineHeight": 1.09
+							}
+						}
+					},
+					"inter": {
+						"typography": {
+							"fontSize": "24px",
+							"lineHeight": 1.4
+						},
+						"breakpoint": {
+							"small-only": {
+								"typography": {
+									"fontSize": "17px"
+								}
 							}
 						}
 					}
@@ -421,6 +447,19 @@
 								"lineHeight": 1.2
 							}
 						}
+					},
+					"inter": {
+						"typography": {
+							"fontSize": "20px",
+							"lineHeight": 1.4
+						},
+						"breakpoint": {
+							"small-only": {
+								"typography": {
+									"fontSize": "15px"
+								}
+							}
+						}
 					}
 				},
 				"level-6": {
@@ -432,6 +471,19 @@
 							"typography": {
 								"fontSize": "18px",
 								"lineHeight": 1.22
+							}
+						}
+					},
+					"inter": {
+						"typography": {
+							"fontSize": "18px",
+							"lineHeight": 1.4
+						},
+						"breakpoint": {
+							"small-only": {
+								"typography": {
+									"fontSize": "14px"
+								}
 							}
 						}
 					}

--- a/source/wp-content/themes/wporg-parent-2021/theme.json
+++ b/source/wp-content/themes/wporg-parent-2021/theme.json
@@ -430,7 +430,7 @@
 						"breakpoint": {
 							"small-only": {
 								"typography": {
-									"fontSize": "17px"
+									"fontSize": "19px"
 								}
 							}
 						}
@@ -456,7 +456,7 @@
 						"breakpoint": {
 							"small-only": {
 								"typography": {
-									"fontSize": "15px"
+									"fontSize": "17px"
 								}
 							}
 						}
@@ -482,7 +482,7 @@
 						"breakpoint": {
 							"small-only": {
 								"typography": {
-									"fontSize": "14px"
+									"fontSize": "16px"
 								}
 							}
 						}


### PR DESCRIPTION
See #163 — This sets up the custom properties for "Inter Heading" font sizes and line heights. This also adds the same "breakpoint" switch as the EB Garamond headings, so using the custom property will automatically switch down to the "small screen" font size at 599px.

This can be used in the child themes like so:

```json
"styles": {
	"elements": {
		"h3": {
			"typography": {
				"fontSize": "var(--wp--custom--heading--level-5--inter--typography--font-size)",
				"lineHeight": "var(--wp--custom--heading--level-5--inter--typography--line-height)"
			}
		}
	}
}
```

### Screenshots

No visual change in this PR, this just makes the properties available.

### How to test the changes in this Pull Request:

Instructions in the child theme repo: https://github.com/WordPress/wporg-photo-directory/pull/37