### PR TITLE
Create linters.yml for linting css & js.

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -1,0 +1,22 @@
+name: Static Analysis (Linting)
+
+# This workflow is triggered on pushes to trunk, and any PRs.
+on:
+  push:
+    branches: [trunk]
+  pull_request:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup
+        uses: WordPress/wporg-repo-tools/.github/actions/setup@trunk
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Lint
+        uses: WordPress/wporg-repo-tools/.github/actions/lint@trunk

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -19,4 +19,4 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Lint
-        uses: WordPress/wporg-repo-tools/.github/actions/lint@trunk
+        uses: WordPress/wporg-repo-tools/.github/actions/lint@try/conditionally-run-php-check

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -19,4 +19,4 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Lint
-        uses: WordPress/wporg-repo-tools/.github/actions/lint@try/conditionally-run-php-check
+        uses: WordPress/wporg-repo-tools/.github/actions/lint@trunk

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
 		"setup:tools": "yarn && composer install && TEXTDOMAIN=wporg composer exec update-configs",
 		"setup:wp": "wp-env run cli bash env/setup.sh",
 		"update:tools": "composer update && TEXTDOMAIN=wporg composer exec update-configs",
-		"wp-env": "wp-env"
+		"wp-env": "wp-env",
+		"lint:php": "echo \"No PHP lint.\""
 	},
 	"workspaces": [
 		"source/wp-content/themes/wporg-parent-2021"

--- a/source/wp-content/themes/wporg-parent-2021/package.json
+++ b/source/wp-content/themes/wporg-parent-2021/package.json
@@ -20,7 +20,8 @@
 		"build": "node build-styles.js",
 		"start": "chokidar \"sass/**/*.scss\" -c \"node build-styles.js\" --initial",
 		"lint:css": "wp-scripts lint-style sass",
-		"lint:js": "echo \"No JS.\""
+		"lint:js": "echo \"No JS.\"",
+		"lint:php": "echo \"No PHP lint.\""
 	},
 	"browserslist": [
 		"extends @wordpress/browserslist-config"

--- a/source/wp-content/themes/wporg-parent-2021/package.json
+++ b/source/wp-content/themes/wporg-parent-2021/package.json
@@ -20,8 +20,7 @@
 		"build": "node build-styles.js",
 		"start": "chokidar \"sass/**/*.scss\" -c \"node build-styles.js\" --initial",
 		"lint:css": "wp-scripts lint-style sass",
-		"lint:js": "echo \"No JS.\"",
-		"lint:php": "echo \"No PHP lint.\""
+		"lint:js": "echo \"No JS.\""
 	},
 	"browserslist": [
 		"extends @wordpress/browserslist-config"


### PR DESCRIPTION
This PR adds a linting to run in PRs, [based on WordPresss/wporg-main-2022](https://github.com/WordPress/wporg-main-2022/blob/trunk/.github/workflows/linters.yml).

Added a php command that does nothing discussed here: https://github.com/WordPress/wporg-repo-tools/pull/33.