### PR TITLE
Try setting the form border color to not be transparent

### DIFF
--- a/source/wp-content/themes/wporg-parent-2021/sass/blocks/_search.scss
+++ b/source/wp-content/themes/wporg-parent-2021/sass/blocks/_search.scss
@@ -46,7 +46,7 @@
 	&.wp-block-search__button-inside {
 		.wp-block-search__inside-wrapper {
 			padding: 0;
-			border-width: var(--wp--custom--form--border--width);
+			border-width: var(--wp--custom--form--search--border--width);
 			border-radius: var(--wp--custom--form--border--radius);
 			background-color: var(--wp--custom--form--search--color--background);
 
@@ -64,7 +64,7 @@
 	&.wp-block-search__button-only,
 	&.wp-block-search__button-outside {
 		.wp-block-search__input {
-			border-width: var(--wp--custom--form--border--width);
+			border-width: var(--wp--custom--form--search--border--width);
 		}
 
 		.wp-block-search__button {

--- a/source/wp-content/themes/wporg-parent-2021/theme.json
+++ b/source/wp-content/themes/wporg-parent-2021/theme.json
@@ -260,10 +260,10 @@
 					"block": "calc(var(--wp--preset--spacing--10) * 0.8)"
 				},
 				"border": {
-					"color": "transparent",
+					"color": "var(--wp--preset--color--charcoal-5)",
 					"radius": "2px",
 					"style": "solid",
-					"width": "0"
+					"width": "1px"
 				},
 				"color": {
 					"label": "inherit",
@@ -286,6 +286,9 @@
 						"label": "var(--wp--preset--color--charcoal-4)",
 						"background": "var(--wp--preset--color--light-grey-2)",
 						"text": "var(--wp--preset--color--charcoal-1)"
+					},
+					"border": {
+						"width": "0"
 					}
 				}
 			},


### PR DESCRIPTION
When [setting up styles for the search box](https://github.com/WordPress/wporg-parent-2021/commit/4330ea36141a66705d6489f84ec8b6e59ca25d15#diff-fef21ca5fc98f62e9e60ad5dcaa4c2f4c4d206ff4ab42cefa234567ddbe92182), we set the form border color to be transparent, with 0 width. This has caused problems for inputs across the site, and we have added styles to child themes to overcome them.

See https://github.com/WordPress/wporg-make/issues/55, the latest report for the Make handbooks. Make has had temporary fixes added to handle this, but those could be removed with this PR merged.

This PR sets the default form border properties to the values we use across the site, and introduces a new custom property for the search border width.

### Screenshots

<!-- If your change has a visual component, add a screenshot here. -->

| Before | After |
|--------|-------|
| ![make wordpress org_photos_handbook_moderating-photos_(Desktop) (1)](https://github.com/user-attachments/assets/6da91da2-362d-4888-a990-37daf41ac272) | ![make wordpress org_photos_handbook_moderating-photos_(Desktop)](https://github.com/user-attachments/assets/cea3bdec-1fdc-4ef8-8d11-679c222781f3) |

### How to test the changes in this Pull Request:

1. Build and load this branch in your sandbox or local environment
2. Check various pages where forms and search forms exist, eg. https://make.wordpress.org/photos/handbook/moderating-photos/, https://wordpress.org/plugins/developers/add/, https://wordpress.org/showcase/submit-a-wordpress-site/
3. The search form field wrapper should have no border, and the form input fields should have a border. You may need to toggle off child theme styles to see the parent styles in effect (definitely the case for Plugin directory, Make handbooks and Showcase).
4. Test focus states