### PR TITLE
Styles: Better balance for headings in Japanese, Korean

### DIFF
--- a/source/wp-content/themes/wporg-parent-2021/inc/rosetta-styles.php
+++ b/source/wp-content/themes/wporg-parent-2021/inc/rosetta-styles.php
@@ -80,9 +80,6 @@ function get_locale_settings( $locale ) {
 								],
 							],
 						],
-						'typography' => [
-							'text-wrap' => 'unset',
-						],
 					],
 				],
 				'typography' => [

--- a/source/wp-content/themes/wporg-parent-2021/sass/base/_elements.scss
+++ b/source/wp-content/themes/wporg-parent-2021/sass/base/_elements.scss
@@ -6,18 +6,44 @@ h4,
 h5,
 h6,
 caption,
-figcaption {
-	text-wrap: var(--wp--custom--heading--typography--text-wrap);
+figcaption,
+p.is-style-serif {
+	text-wrap: balance;
 	overflow-wrap: initial;
 	word-break: initial;
+
+	&:lang(ja) {
+		text-wrap: initial;
+
+		// "auto-phrase" automatically detects words and breaks after them, for
+		// languages that don't use spaces between words. If this is available,
+		// we can use it with "balance" to wrap text in a localized way.
+		// Only supported by Chromium browsers currently.
+		@supports (word-break: auto-phrase) {
+			word-break: auto-phrase;
+			text-wrap: balance;
+		}
+	}
+
+	&:lang(ko) {
+		// By default, Korean breaks at syllables, but for a nicer reading
+		// experience we want to break at words.
+		word-break: keep-all;
+
+		@media (max-width: 480px) {
+			// Except on small screens, to prevent overflow.
+			text-wrap: wrap;
+			word-break: initial;
+		}
+	}
 }
 
-// Prevent orphans
 p,
 ul,
 ol,
 blockquote {
-	text-wrap: var(--wp--custom--body--typography--text-wrap);
+	// Prevent orphans.
+	text-wrap: pretty;
 }
 
 // Links


### PR DESCRIPTION
See #150, #123. We've established that `text-wrap: balance` doesn't work well for Japanese, but words can still be cut off at the end of a line, and the headings are not visually balanced. Balance alone doesn't work well for Korean either, as it also defaults to cutting off words.

Here's an example of the problem— the red is around a single word split between the lines.

![demo](https://github.com/user-attachments/assets/921d1a72-8c5c-4946-b274-a990fc90a1b5)

![demo-ja](https://github.com/user-attachments/assets/eb2e6b9e-93cc-478a-8997-cef614541c5a)

This proposes an alternate fix to #123, where we don't need to set and override a theme.json variable but instead intelligently apply the balanced wrapping by taking advantage of an early CSS property for phrase detection in Japanese. This allows the browser to process the text and break at words.

This also adds the `keep-all` fix for Korean, which keeps words together and just uses spaces for line wrapping.

With both of those properties, `text-wrap: balance` works similarly to how it does in English, balancing headings without breaking words.

cc-ing some previously involved people — @taggon @mkismy @t-hamano

### Screenshots

In the below screenshots, we have the "before" state where balance was disabled. The "After" is in Chrome, where phrase detection (`word-wrap: auto-phrase`) exists so we can balance text, and the last column is Firefox, where we don't have phrase detection, so balance is still disabled.

| Before | After (Chrome, or Safari with feature flag) | After (Firefox) |
|--------|-------|----|
| ![before-ja-download](https://github.com/user-attachments/assets/cb43d3c2-fcfc-4f2d-8bcb-fc8db168aacf) | ![after-ja-download](https://github.com/user-attachments/assets/1ce907bc-fbe8-4b73-8082-2fa775cdee23) | ![after-ja-download-firefox](https://github.com/user-attachments/assets/863cc23a-db65-444b-b527-08f874dd39e9) |
| ![before-ja-home](https://github.com/user-attachments/assets/f8296a30-b0db-4d0c-b629-15afc4fd60c3) | ![after-ja-home](https://github.com/user-attachments/assets/91306e2f-469d-45bc-8e9d-e184bbc63366) | ![after-ja-home-firefox](https://github.com/user-attachments/assets/8107be8b-0c15-499f-9a7e-26da23a06eb1) |
| ![before-ja-news](https://github.com/user-attachments/assets/a7b0fa47-fccd-4a67-83b8-1407badd57ea) | ![after-ja-news](https://github.com/user-attachments/assets/b9c7393f-e216-4a85-bb01-a49fc4e2bb0d) | ![after-ja-news-firefox](https://github.com/user-attachments/assets/1e0305b3-420a-40a1-a247-0340b4640a04) |

This last example ^ seems a little awkward, I think the line splitter doesn't know how to handle the version number, and "メンテナンスリリース" is not parsed as two words [by the phrase detection algorithm](https://google.github.io/budoux/?q=WordPress+6.7.2%E3%83%A1%E3%83%B3%E3%83%86%E3%83%8A%E3%83%B3%E3%82%B9%E3%83%AA%E3%83%AA%E3%83%BC%E3%82%B9) (because it's a loan word?)

There are no browser concerns with `word-wrap: keep-all`, so this looks the same across all. On small screens, `keep-all` is removed to prevent overflow on large text.

| Before | After |
|--------|-------|
| ![before-ko-download](https://github.com/user-attachments/assets/1d623769-ca01-4601-8bc4-64fd22f17523) | ![after-ko-download](https://github.com/user-attachments/assets/29ee4dd0-c389-45b7-976b-b94a410b84a4) | 
| ![before-ko-home](https://github.com/user-attachments/assets/70213d86-25d3-4204-96b4-f9b4daafb92f) | ![after-ko-home](https://github.com/user-attachments/assets/ace613f3-d144-480f-b4e4-69effa1bd7df) |
| ![before-ko-page](https://github.com/user-attachments/assets/4696bd82-0064-4c6b-be31-603a4a62bcdb) | ![after-ko-page](https://github.com/user-attachments/assets/ff554ad2-ccaf-4fb3-8936-b865795f1eb1) |
| ![Screen Shot 2025-03-20 at 15 52 43](https://github.com/user-attachments/assets/5dd97fc6-afd4-4e8a-ae90-8d16370e6272) | ![Screen Shot 2025-03-20 at 15 53 33](https://github.com/user-attachments/assets/bdc5a10f-b8b3-4d87-91a4-1863357b5ff6) |

### How to test the changes in this Pull Request:

1. Apply the PR to the parent theme
2. Start up [the main theme environment with Japanese or Korean](https://github.com/WordPress/wporg-main-2022/?tab=readme-ov-file#working-on-non-english-sites)
3. View the homepage, other pages
4. Headings should be balanced, but not break up words. On Korean you can see the spaces in inspect element. For Japanese it's easier to check if you speak the language… I relied a lot on my college Japanese class + google translate 😅

