### PR TITLE
Fonts: Add Noto Serif SC for `zh_CN` locale, use filter for preloading fonts

### DIFF
--- a/source/wp-content/themes/wporg-parent-2021/functions.php
+++ b/source/wp-content/themes/wporg-parent-2021/functions.php
@@ -88,7 +88,8 @@ function enqueue_assets() {
 		/*
 		 * translators: Font subset for your locale. Can be any of cyrillic,
 		 * cyrillic-ext, greek, greek-ext, vietnamese, latin, latin-ext.
-		 * Do not translate into your own language.
+		 * Do not translate into your own language. If you don't use EB Garamond
+		 * for headings, you can ignore this.
 		 */
 		$subsets = _x( 'latin', 'EB Garamond subsets, comma separated', 'wporg' );
 		list( $font, $subsets ) = apply_filters( 'wporg_preload_heading_font', [ 'EB Garamond', $subsets ] );

--- a/source/wp-content/themes/wporg-parent-2021/functions.php
+++ b/source/wp-content/themes/wporg-parent-2021/functions.php
@@ -82,6 +82,18 @@ function enqueue_assets() {
 		'print'
 	);
 	wp_style_add_data( 'wporg-parent-2021-print', 'rtl', 'replace' );
+
+	// Preload the heading font.
+	if ( is_callable( 'global_fonts_preload' ) ) {
+		/*
+		 * translators: Font subset for your locale. Can be any of cyrillic,
+		 * cyrillic-ext, greek, greek-ext, vietnamese, latin, latin-ext.
+		 * Do not translate into your own language.
+		 */
+		$subsets = _x( 'latin', 'EB Garamond subsets, comma separated', 'wporg' );
+		list( $font, $subsets ) = apply_filters( 'wporg_preload_heading_font', [ 'EB Garamond', $subsets ] );
+		global_fonts_preload( $font, $subsets );
+	}
 }
 
 /**

--- a/source/wp-content/themes/wporg-parent-2021/inc/rosetta-styles.php
+++ b/source/wp-content/themes/wporg-parent-2021/inc/rosetta-styles.php
@@ -29,6 +29,8 @@ function update_preload_heading_font( $font_pair ) {
 	// First check if it should be a different font.
 	if ( 'ja' === get_locale() ) {
 		$font_pair = [ 'Noto Serif JP', 'cjk' ];
+	} else if ( 'zh_CN' === get_locale() ) {
+		$font_pair = [ 'Noto Serif SC', 'cjk' ];
 	} else if ( 'ckb' === get_locale() ) {
 		$font_pair = [ 'Noto Kufi', 'arabic' ];
 	}
@@ -197,6 +199,25 @@ function get_locale_settings( $locale ) {
 					],
 				],
 			];
+		case 'zh_CN':
+			return [
+				'custom' => [
+					'heading' => [
+						'typography' => [
+							'fontFamily' => 'var(--wp--preset--font-family--noto-serif-sc)'
+						],
+					],
+				],
+				'typography' => [
+					'fontFamilies' => [
+						[
+							'fontFamily' => '"Noto Serif SC", serif',
+							'slug' => 'noto-serif-sc',
+							'name' => 'Noto Serif SC',
+						],
+					],
+				],
+			];
 	}
 	return false;
 }
@@ -240,6 +261,18 @@ CSS,
 						],
 					],
 				],
+			];
+		case 'zh_CN':
+			return [
+				// Force any inline-styled headings to use Noto Serif SC.
+				'css' => <<<CSS
+* {
+	--wp--preset--font-family--eb-garamond: var(--wp--preset--font-family--noto-serif-sc) !important;
+}
+span.global-footer__code_is_poetry {
+	font-family: var(--wp--preset--font-family--noto-serif-sc) !important;
+}
+CSS,
 			];
 	}
 }

--- a/source/wp-content/themes/wporg-parent-2021/inc/rosetta-styles.php
+++ b/source/wp-content/themes/wporg-parent-2021/inc/rosetta-styles.php
@@ -8,6 +8,53 @@ namespace WordPressdotorg\Theme\Parent_2021\Rosetta_Styles;
 defined( 'WPINC' ) || die();
 
 add_filter( 'wp_theme_json_data_user', __NAMESPACE__ . '\inject_i18n_customizations' );
+add_filter( 'wporg_preload_heading_font', __NAMESPACE__ . '\update_preload_heading_font' );
+add_filter( 'wporg_preload_body_font', __NAMESPACE__ . '\update_preload_body_font' );
+
+/**
+ * Update the font to preload for headings.
+ *
+ * This does not impact loading the font, just the `preload` hint.
+ *
+ * @param array $font_pair {
+ *     An array with [$font, $subset].
+ *
+ *     @type string $0 Font name(s).
+ *     @type string $1 Subset(s).
+ * }
+ *
+ * @return string[] Updated (font, subset) pair.
+ */
+function update_preload_heading_font( $font_pair ) {
+	// First check if it should be a different font.
+	if ( 'ja' === get_locale() ) {
+		$font_pair = [ 'Noto Serif JP', 'cjk' ];
+	} else if ( 'ckb' === get_locale() ) {
+		$font_pair = [ 'Noto Kufi', 'arabic' ];
+	}
+	return $font_pair;
+}
+
+/**
+ * Update the font to preload for body text.
+ *
+ * This does not impact loading the font, just the `preload` hint.
+ *
+ * @param array $font_pair {
+ *     An array with [$font, $subset].
+ *
+ *     @type string $0 Font name(s).
+ *     @type string $1 Subset(s).
+ * }
+ *
+ * @return array{string,string} Updated (font, subset) pair.
+ */
+function update_preload_body_font( $font_pair ) {
+	if ( 'ckb' === get_locale() ) {
+		$font_pair = [ 'Noto Kufi', 'arabic' ];
+	}
+	return $font_pair;
+}
 
 /**
  * Inject customizations for Rosetta sites.

--- a/source/wp-content/themes/wporg-parent-2021/inc/rosetta-styles.php
+++ b/source/wp-content/themes/wporg-parent-2021/inc/rosetta-styles.php
@@ -128,6 +128,7 @@ function get_locale_settings( $locale ) {
 							],
 						],
 						'typography' => [
+							'fontFamily' => 'var(--wp--preset--font-family--noto-serif-jp)',
 							'text-wrap' => 'unset',
 						],
 					],

--- a/source/wp-content/themes/wporg-parent-2021/inc/rosetta-styles.php
+++ b/source/wp-content/themes/wporg-parent-2021/inc/rosetta-styles.php
@@ -26,14 +26,11 @@ add_filter( 'wporg_preload_body_font', __NAMESPACE__ . '\update_preload_body_fon
  * @return string[] Updated (font, subset) pair.
  */
 function update_preload_heading_font( $font_pair ) {
-	// First check if it should be a different font.
-	if ( 'ja' === get_locale() ) {
-		$font_pair = [ 'Noto Serif JP', 'cjk' ];
-	} else if ( 'ko_KR' === get_locale() ) {
-		$font_pair = [ 'Noto Serif KR', 'cjk' ];
-	} else if ( 'zh_CN' === get_locale() ) {
-		$font_pair = [ 'Noto Serif SC', 'cjk' ];
-	} else if ( 'ckb' === get_locale() ) {
+	$locale = get_locale();
+	if ( in_array( $locale, [ 'ja', 'ko_KR', 'zh_CN' ] ) ) {
+		// For these locales, we have font subsets which cannot be preloaded.
+		$font_pair = [ false, false ];
+	} else if ( 'ckb' === $locale ) {
 		$font_pair = [ 'Noto Kufi', 'arabic' ];
 	}
 	return $font_pair;
@@ -54,7 +51,11 @@ function update_preload_heading_font( $font_pair ) {
  * @return array{string,string} Updated (font, subset) pair.
  */
 function update_preload_body_font( $font_pair ) {
-	if ( 'ckb' === get_locale() ) {
+	$locale = get_locale();
+	if ( in_array( $locale, [ 'ja', 'ko_KR', 'zh_CN' ] ) ) {
+		// Inter is not supported, no need to preload it.
+		$font_pair = [ false, false ];
+	} else if ( 'ckb' === $locale ) {
 		$font_pair = [ 'Noto Kufi', 'arabic' ];
 	}
 	return $font_pair;

--- a/source/wp-content/themes/wporg-parent-2021/inc/rosetta-styles.php
+++ b/source/wp-content/themes/wporg-parent-2021/inc/rosetta-styles.php
@@ -130,7 +130,6 @@ function get_locale_settings( $locale ) {
 							],
 						],
 						'typography' => [
-							'fontFamily' => 'var(--wp--preset--font-family--noto-serif-jp)',
 							'text-wrap' => 'unset',
 						],
 					],
@@ -201,13 +200,6 @@ function get_locale_settings( $locale ) {
 			];
 		case 'zh_CN':
 			return [
-				'custom' => [
-					'heading' => [
-						'typography' => [
-							'fontFamily' => 'var(--wp--preset--font-family--noto-serif-sc)'
-						],
-					],
-				],
 				'typography' => [
 					'fontFamilies' => [
 						[
@@ -237,7 +229,17 @@ function get_locale_styles( $locale ) {
 	switch ( $locale ) {
 		case 'ja':
 			return [
-				'css' => 'body { font-feature-settings: "palt"; }',
+				'css' => <<<CSS
+* {
+	--wp--preset--font-family--eb-garamond: var(--wp--preset--font-family--noto-serif-jp) !important;
+}
+body {
+	font-feature-settings: "palt";
+}
+span.global-footer__code_is_poetry {
+	font-family: var(--wp--preset--font-family--noto-serif-jp) !important;
+}
+CSS,
 			];
 		case 'ckb':
 			return [

--- a/source/wp-content/themes/wporg-parent-2021/inc/rosetta-styles.php
+++ b/source/wp-content/themes/wporg-parent-2021/inc/rosetta-styles.php
@@ -29,6 +29,8 @@ function update_preload_heading_font( $font_pair ) {
 	// First check if it should be a different font.
 	if ( 'ja' === get_locale() ) {
 		$font_pair = [ 'Noto Serif JP', 'cjk' ];
+	} else if ( 'ko_KR' === get_locale() ) {
+		$font_pair = [ 'Noto Serif KR', 'cjk' ];
 	} else if ( 'zh_CN' === get_locale() ) {
 		$font_pair = [ 'Noto Serif SC', 'cjk' ];
 	} else if ( 'ckb' === get_locale() ) {
@@ -158,6 +160,18 @@ function get_locale_settings( $locale ) {
 					],
 				],
 			];
+		case 'ko_KR':
+			return [
+				'typography' => [
+					'fontFamilies' => [
+						[
+							'fontFamily' => '"Noto Serif KR", serif',
+							'slug' => 'noto-serif-kr',
+							'name' => 'Noto Serif KR',
+						],
+					],
+				],
+			];
 		case 'ckb':
 			return [
 				'custom' => [
@@ -238,6 +252,17 @@ body {
 }
 span.global-footer__code_is_poetry {
 	font-family: var(--wp--preset--font-family--noto-serif-jp) !important;
+}
+CSS,
+			];
+		case 'ko_KR':
+			return [
+				'css' => <<<CSS
+* {
+	--wp--preset--font-family--eb-garamond: var(--wp--preset--font-family--noto-serif-kr) !important;
+}
+span.global-footer__code_is_poetry {
+	font-family: var(--wp--preset--font-family--noto-serif-kr) !important;
 }
 CSS,
 			];


### PR DESCRIPTION
Fixes #149, see https://github.com/WordPress/wporg-mu-plugins/pull/684. This cleans up the font preloading slightly by moving the heading font preload call into the parent theme, and adding a filter around which font/subset is preloaded. This will help future updates by keeping the source of the font in `mu-plugins/global-fonts` and the loading of it in the parent theme's `rosetta-styles.php`. Initially the heading font was preloaded in each child theme to support different fonts per site, but that's not necessary and adds an extra step.

In addition to the filter & cleanup, this also loads Noto Serif SC for the Chinese (China) locale, and updates the Japanese locale to use Noto Serif JP anywhere EB Garamond had been.

Props @devhaozi.

### Screenshots

| Before | After |
|--------|-------|
| ![cn-eb-garamond](https://github.com/user-attachments/assets/eb515c20-b6a4-4289-b8f3-d6b20e44ef2f) | ![cn-noto-serif](https://github.com/user-attachments/assets/3020d9bf-1e8d-43c6-93fd-941eb78b3072) |

### How to test the changes in this Pull Request:

1. Load up this PR and https://github.com/WordPress/wporg-mu-plugins/pull/684
2. Set your site's language to Japanese or Chinese
3. View any page, it should preload Noto Serif SC or JP (view source to see)
4. Headings should be using the relevant Noto Serif.
