### PR TITLE
Fonts: Add Noto Serif KR

### DIFF
--- a/source/wp-content/themes/wporg-parent-2021/inc/rosetta-styles.php
+++ b/source/wp-content/themes/wporg-parent-2021/inc/rosetta-styles.php
@@ -257,7 +257,6 @@ CSS,
 			];
 		case 'ko_KR':
 			return [
-				// Force any inline-styled headings to use Noto Serif SC.
 				'css' => <<<CSS
 * {
 	--wp--preset--font-family--eb-garamond: var(--wp--preset--font-family--noto-serif-kr) !important;

--- a/source/wp-content/themes/wporg-parent-2021/inc/rosetta-styles.php
+++ b/source/wp-content/themes/wporg-parent-2021/inc/rosetta-styles.php
@@ -29,6 +29,8 @@ function update_preload_heading_font( $font_pair ) {
 	// First check if it should be a different font.
 	if ( 'ja' === get_locale() ) {
 		$font_pair = [ 'Noto Serif JP', 'cjk' ];
+	} else if ( 'ko_KR' === get_locale() ) {
+		$font_pair = [ 'Noto Serif KR', 'cjk' ];
 	} else if ( 'zh_CN' === get_locale() ) {
 		$font_pair = [ 'Noto Serif SC', 'cjk' ];
 	} else if ( 'ckb' === get_locale() ) {
@@ -158,6 +160,18 @@ function get_locale_settings( $locale ) {
 					],
 				],
 			];
+		case 'ko_KR':
+			return [
+				'typography' => [
+					'fontFamilies' => [
+						[
+							'fontFamily' => '"Noto Serif KR", serif',
+							'slug' => 'noto-serif-kr',
+							'name' => 'Noto Serif KR',
+						],
+					],
+				],
+			];
 		case 'ckb':
 			return [
 				'custom' => [
@@ -238,6 +252,18 @@ body {
 }
 span.global-footer__code_is_poetry {
 	font-family: var(--wp--preset--font-family--noto-serif-jp) !important;
+}
+CSS,
+			];
+		case 'ko_KR':
+			return [
+				// Force any inline-styled headings to use Noto Serif SC.
+				'css' => <<<CSS
+* {
+	--wp--preset--font-family--eb-garamond: var(--wp--preset--font-family--noto-serif-kr) !important;
+}
+span.global-footer__code_is_poetry {
+	font-family: var(--wp--preset--font-family--noto-serif-kr) !important;
 }
 CSS,
 			];


### PR DESCRIPTION
Fixes https://github.com/WordPress/wporg-parent-2021/issues/175. When viewing a Korean site, it should use Noto Serif KR for the headings, not EB Garamond.

Props @Jiwoon-Kim.

(note that this is built on #173, because it simplifies the font loading slightly.)

### Screenshots

| Before | After |
|--------|-------|
| ![ko-eb-garamond](https://github.com/user-attachments/assets/67b50892-3d1b-414f-93b4-e6be51cb528a) | ![ko-noto-serif](https://github.com/user-attachments/assets/e83f7e37-5162-4656-963c-562fe687bca7) |

### How to test the changes in this Pull Request

1. Load up this PR and https://github.com/WordPress/wporg-mu-plugins/pull/685
2. Set your site's language to Korean
3. View any page, it should preload Noto Serif KR (view source to see)
4. Headings should be using the Noto Serif KR
