### PR TITLE
Revert "Change heading size in Japanese locale (#138)"

### DIFF
--- a/source/wp-content/themes/wporg-parent-2021/inc/rosetta-styles.php
+++ b/source/wp-content/themes/wporg-parent-2021/inc/rosetta-styles.php
@@ -99,10 +99,6 @@ function get_locale_settings( $locale ) {
 							'size' => '70px',
 						],
 						[
-							'slug' => 'heading-1',
-							'size' => '60px',
-						],
-						[
 							'slug' => 'heading-2',
 							'size' => '40px',
 						],


### PR DESCRIPTION
This PR reverts #138

As part of adjustments to the Japanese Rosetta site, we changed the size of h1 headings from `70px` to `60px` because they were too large in Japanese.

While this change was intentional on the Rosetta site, the headings unintentionally affected the forum's `h1` title.

**English Support Forum**: the `h1` title is `36px` in size.

https://wordpress.org/support/topic/titles-info-card-not-showing-caps/

<img width="1426" height="669" alt="english" src="https://github.com/user-attachments/assets/ae41a824-e055-47b6-a3ba-f42fa267a676" />

**Japanese Support Forum**: the `h1` title is `60px` in size.

https://ja.wordpress.org/support/topic/%e3%82%a4%e3%83%b3%e3%82%bf%e3%83%bc%e3%83%8d%e3%83%83%e3%83%88%e4%b8%8a%e3%81%abwordpress%e3%81%ae%e7%b7%a8%e9%9b%86%e7%94%bb%e9%9d%a2%e3%81%8c%e5%87%ba%e3%81%a6%e5%9b%b0%e3%82%8b/

<img width="1429" height="667" alt="japanese" src="https://github.com/user-attachments/assets/1abc05ea-08eb-4bde-b80f-f6d295861554" />

Because this font size change is problematic, we have decided to remove the Japanese locale-specific override. I understand that this PR will revert 60px headings on the Rosetta site to 70px, and this decision was reached after discussion within the Japanese community.