### PR TITLE
Gallery block: Remove blur from captioned images in galleries

### DIFF
--- a/source/wp-content/themes/wporg-parent-2021/sass/base/_elements.scss
+++ b/source/wp-content/themes/wporg-parent-2021/sass/base/_elements.scss
@@ -86,12 +86,17 @@ figure[class*="wp-block-"],
 				height: auto;
 			}
 
+			&:has(figcaption)::before {
+				display: none;
+			}
+
 			figcaption,
 			.wp-element-caption {
 				position: static;
 				margin: calc(var(--wp--style--block-gap) / 2) 0 0;
 				padding: 0;
 				background: transparent;
+				text-shadow: none;
 				color: var(--wp--preset--color--charcoal-4);
 				font-size: var(--wp--custom--gallery--caption--font-size);
 				line-height: 1.6;


### PR DESCRIPTION
The parent theme changes how gallery image captions work slightly— instead of overlapping images, they're under the image. However the core blocks assume they'll overlap the image, and be on a dark background. To make the caption more readable, core adds a text shadow and image blur. This makes our captions harder to read, and the image distorted. This PR removes those styles, so that caption styling on images in galleries matches the styling on regular image blocks.

### Screenshots

<!-- If your change has a visual component, add a screenshot here. -->

| Before | After |
|--------|-------|
| <img width="1468" height="2240" alt="Screenshot 2025-10-29 at 4 54 51 PM" src="https://github.com/user-attachments/assets/19ac7163-1495-46cb-9d91-7c40aa72e684" /> | <img width="1452" height="2246" alt="Screenshot 2025-10-29 at 5 02 32 PM" src="https://github.com/user-attachments/assets/c72eeb12-935e-4680-b759-dc60ba3d3b63" /> |

### How to test the changes in this Pull Request:

1. Apply the PR and create a post/page with a gallery block, add a caption to the image
2. For example, I have a draft demo here: https://wordpress.org/?p=23595
3. The caption and image should not be distorted

